### PR TITLE
フッターにルーム名を表示する

### DIFF
--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -175,6 +175,7 @@
     <div class="box" id="footer">
       <dl>
         <dt>入室</dt><dd id="member-num" class="link" onclick="boxOpen('member-list')">－</dd>
+        <dt>ルーム</dt><dd><TMPL_VAR title></dd>
         <dt>システム</dt><dd style="white-space: nowrap;"><TMPL_VAR gameSystemName></dd>
       </dl>
       <dl>


### PR DESCRIPTION
# 内容

　フッターにルーム名を表示する。

# 目的

　複数のルームを連続または併行して利用していると、現在地を見失うおそれがある、またはその可能性に対して不安になる。
　（一例として、実セッション用のルームと、テスト用のルームを併行して利用している場合など）

　[スマートフォン環境向けのヘッダにはルーム名がもとから表示されている](https://github.com/yutorize/ytchat-adv/blob/develop/lib/html/room.html#L48)し、存在しても不自然ではないはず。
