### PR TITLE
行送りを広げるタグを追加

### DIFF
--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -151,6 +151,8 @@ button, .button {
 .left  { text-align: left; }
 .center{ text-align: center; }
 .right { text-align: right; }
+.add-line-spacing { line-height: 2.1; }
+.add-line-spacing ruby { line-height: 2.4; }
 
 img.icon { width: 1em; height: 1em; }
 

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -881,6 +881,10 @@ body.rom .input-form { display: none !important; }
 .decoration-buttons .insert-left::before    { content:"\f036"; }
 .decoration-buttons .insert-center::before  { content:"\f037"; }
 .decoration-buttons .insert-right::before   { content:"\f038"; }
+.decoration-buttons .insert-add-line-spacing::before   { content:"\f034"; }
+/* for Font Awesome Pro
+.decoration-buttons .insert-add-line-spacing::before   { content:"\f871"; }
+*/
 
 .decoration-buttons .insert-image::before   { content:"\f03e"; color:#8fd; }
 

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -123,7 +123,8 @@
             <span class="button insert-horizon"   title="水平線"></span>
             <span class="button insert-left"      title="左揃え"></span>
             <span class="button insert-center"    title="中央揃え"></span>
-            <span class="button end insert-right" title="右揃え"></span>
+            <span class="button insert-right" title="右揃え"></span>
+            <span class="button end insert-add-line-spacing" title="行送りを大きく"></span>
             
             <span class="button start end insert-image" title="挿絵" onclick="boxOpen('image-insert');"></span>
           </div>

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1381,6 +1381,12 @@ $(".insert-right").click(function(){
     .selection("insert", {text: "</right>", mode: "after"});
   autosizeUpdate(formCommMain);
 });
+$(".insert-add-line-spacing").click(function(){
+  $("#form-comm-main")
+    .selection("insert", {text: "<add-line-spacing>", mode: "before"})
+    .selection("insert", {text: "</add-line-spacing>", mode: "after"});
+  autosizeUpdate(formCommMain);
+});
 
 // 音量調節 ----------------------------------------
 let volumes = {};

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -369,6 +369,7 @@ sub tagConvert{
   1 while $comm =~ s#&lt;left&gt;(.*?)&lt;/left&gt;\n?#<div class="left">$1</div>#gis;
   1 while $comm =~ s#&lt;center&gt;(.*?)&lt;/center&gt;\n?#<div class="center">$1</div>#gis;
   1 while $comm =~ s#&lt;right&gt;(.*?)&lt;/right&gt;\n?#<div class="right">$1</div>#gis;
+  1 while $comm =~ s#&lt;add-line-spacing&gt;(.*?)&lt;/add-line-spacing&gt;\n?#<div class="add-line-spacing">$1</div>#gis;
   
   # 自動リンク
   $comm =~ s#((?:\G|>)[^<]*?)(https?://[^\s\<]+)#$1<a href="$2" target="_blank">$2</a>#gi;


### PR DESCRIPTION
# 内容

- 行送りを拡げるタグを追加

# 経緯

　詠唱呪文やナレーションなど、ある種の演出は行間が大きいほうが見栄えがよいので。
　（そして行間調整のために空行を使うのは美しくない）

# 実装に関する補足

- 用途や挙動を踏まえ、位置指定系のタグ（ left / right / center ）と近似のあつかいにしました。
- ルビ（ ruby ）だけさらに拡げるようにしたのは、そのほうが見栄えのバランスがよいからです。
- Font Awesome Free に適切なアイコン（ _line-height_ ）がなかったので、似たような別の意味のやつ（ _text-height_ ）で妥協しました……。（ [Proにはある](https://fontawesome.com/v5.15/icons/line-height)）

# 動作イメージ

![image](https://user-images.githubusercontent.com/44130782/133352456-e24f3a33-a0db-4514-9130-f0e996f7f74a.png)
