### PR TITLE
ヘルプ内を検索する機能を追加

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -1357,6 +1357,39 @@ body.rom .input-form { display: none !important; }
 #help-window table.help-rate-table th:nth-child(2) {
   white-space: nowrap;
 }
+#help-window .search-form {
+  margin: 0.5em 0 1em 0;
+}
+#help-window .search-form label {
+  margin-right: 0.5em;
+}
+#help-window .search-form label input[type="text"] {
+  width: min(50%, 20em);
+}
+#help-window.search-mode {
+  --markup-color-r: 255;
+  --markup-color-g: 165;
+  --markup-color-b: 0;
+}
+#help-window.search-mode .contains-search-matched {
+  --markup-color: rgba(var(--markup-color-r), var(--markup-color-g), var(--markup-color-b), 0.10);
+  --markup-offset: 1px;
+  --markup-blur: 1em;
+  --markup-spread: 8px;
+  box-shadow: inset var(--markup-offset) var(--markup-offset) var(--markup-blur) var(--markup-spread) var(--markup-color),
+  inset var(--markup-offset) calc(var(--markup-offset) * -1) var(--markup-blur) var(--markup-spread) var(--markup-color),
+  inset calc(var(--markup-offset) * -1) var(--markup-offset) var(--markup-blur) var(--markup-spread) var(--markup-color),
+  inset calc(var(--markup-offset) * -1) calc(var(--markup-offset) * -1) var(--markup-blur) var(--markup-spread) var(--markup-color);
+}
+#help-window.search-mode .search-matched {
+  background-color: rgba(var(--markup-color-r), var(--markup-color-g), var(--markup-color-b), 0.65);
+}
+#help-window.search-mode details {
+  display: none;
+}
+#help-window.search-mode details.search-matched, #help-window.search-mode details.contains-search-matched {
+  display: block;
+}
 
 .mem-signal::before {
   display: inline-block;

--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -1,3 +1,11 @@
+<div class="search-form">
+  <label>
+    <span class="fa fa-search"></span>
+    <input type="text" placeholder="ヘルプ内を検索" />
+  </label>
+  <button class="to-clear">Clear</button>
+</div>
+
 <details>
   <summary>キーボードショートカット</summary>
   <table>

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1869,10 +1869,11 @@ function statusListSave(){
   localStorage.setItem(roomId+'-statusList', JSON.stringify(statusList));
 }
 
-(function ($) {
-  const $helpWindow = $('#help-window');
-  const $searchTextField = $helpWindow.find('.search-form input[type="text"]');
-  const $buttonToClear = $helpWindow.find('.search-form button.to-clear');
+// ヘルプ内検索 ----------------------------------------
+(function(){
+  const helpWindow = document.getElementById('help-window');
+  const searchTextField = helpWindow.querySelector('.search-form input[type="text"]');
+  const buttonToClear = helpWindow.querySelector('.search-form button.to-clear');
 
   const normalizeText = (function () {
     const cache = {};
@@ -1886,55 +1887,60 @@ function statusListSave(){
     };
   })();
 
-  $searchTextField.on(
-      'input change',
-      function () {
-        const searchText = normalizeText($searchTextField.val());
+  searchTextField.addEventListener(
+    'input',
+    function () {
+      const searchText = normalizeText(searchTextField.value);
+      
+      const searchModeClassName = 'search-mode';
+      if (searchText === '') {
+        helpWindow.classList.remove(searchModeClassName);
+        return;
+      }
+      helpWindow.classList.add(searchModeClassName);
 
-        const searchModeClassName = 'search-mode';
-        if (searchText === '') {
-          $helpWindow.removeClass(searchModeClassName);
-          return;
-        }
+      const searchMatchingClassName = 'search-matched';
+      const searchMatchingContainerClassName = 'contains-search-matched';
+      
+      helpWindow.querySelectorAll(`.box-body .${searchMatchingClassName}`).forEach(obj => {
+        obj.classList.remove(searchMatchingClassName);
+      });
+      helpWindow.querySelectorAll(`.box-body .${searchMatchingContainerClassName}`).forEach(obj => {
+        obj.classList.remove(searchMatchingContainerClassName);
+      });
 
-        $helpWindow.addClass(searchModeClassName);
+      const excludeContainerNodeTypes = ['THEAD', 'TBODY', 'TFOOT', 'TR', 'UL', 'OL', 'DL'];
+      helpWindow.querySelectorAll('.box-body details').forEach(details => {
+        details.querySelectorAll('summary, p, th, td, dt, dd, h3, h4, h5, h6').forEach(
+          function (node) {
+            const nodeText = normalizeText(node.textContent);
 
-        const searchMatchingClassName = 'search-matched';
-        const searchMatchingContainerClassName = 'contains-search-matched';
-        $helpWindow.find(`.box-body .${searchMatchingClassName}`).removeClass(searchMatchingClassName);
-        $helpWindow.find(`.box-body .${searchMatchingContainerClassName}`).removeClass(searchMatchingContainerClassName);
+            if (!nodeText.includes(searchText)) {
+              return;
+            }
 
-        const excludeContainerNodeTypes = ['THEAD', 'TBODY', 'TFOOT', 'TR', 'UL', 'OL', 'DL'];
-        $helpWindow.find('.box-body details').find('summary, p, th, td, dt, dd, h3, h4, h5, h6').each(
-            function (_, node) {
-              const $node = $(node);
-              const nodeText = normalizeText($node.text());
-
-              if (!nodeText.includes(searchText)) {
-                return;
-              }
-
-              $node.addClass(searchMatchingClassName);
-
-              {
-                let $current = $node.parent();
-                while (
-                    !$current.hasClass('box-body') &&
-                    !$current.hasClass(searchMatchingClassName) &&
-                    !$current.hasClass(searchMatchingContainerClassName)
-                    ) {
-                  if (!excludeContainerNodeTypes.includes($current[0].nodeName)) {
-                    $current.addClass(searchMatchingContainerClassName);
-                    if ($current[0].nodeName === 'DETAILS') {
-                      $current.attr('open', '');
-                    }
+            node.classList.add(searchMatchingClassName);
+                
+            {
+              let current = node.parentNode;
+              while (
+                  !current.classList.contains('box-body') &&
+                  !current.classList.contains(searchMatchingClassName) &&
+                  !current.classList.contains(searchMatchingContainerClassName)
+              ) {
+                if (!excludeContainerNodeTypes.includes(current.nodeName)) {
+                  current.classList.add(searchMatchingContainerClassName);
+                  if (current.nodeName === 'DETAILS') {
+                    current.setAttribute('open', '');
                   }
-                  $current = $current.parent();
                 }
+                current = current.parentNode;
               }
             }
+          }
         );
-      }
+      });
+    }
   );
 
   $buttonToClear.on(

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1949,7 +1949,7 @@ function statusListSave(){
         $searchTextField.val('').trigger('change');
       }
   );
-})($);
+})();
 
 // スマホ用 ----------------------------------------
 $(window).resize(function(){

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1869,6 +1869,82 @@ function statusListSave(){
   localStorage.setItem(roomId+'-statusList', JSON.stringify(statusList));
 }
 
+(function ($) {
+  const $helpWindow = $('#help-window');
+  const $searchTextField = $helpWindow.find('.search-form input[type="text"]');
+  const $buttonToClear = $helpWindow.find('.search-form button.to-clear');
+
+  const normalizeText = (function () {
+    const cache = {};
+    return function normalizeText(text) {
+      if (text in cache) {
+        return cache[text];
+      }
+      const normalized = toHalfWidth(text).toLowerCase();
+      cache[text] = normalized;
+      return normalized;
+    };
+  })();
+
+  $searchTextField.on(
+      'input change',
+      function () {
+        const searchText = normalizeText($searchTextField.val());
+
+        const searchModeClassName = 'search-mode';
+        if (searchText === '') {
+          $helpWindow.removeClass(searchModeClassName);
+          return;
+        }
+
+        $helpWindow.addClass(searchModeClassName);
+
+        const searchMatchingClassName = 'search-matched';
+        const searchMatchingContainerClassName = 'contains-search-matched';
+        $helpWindow.find(`.box-body .${searchMatchingClassName}`).removeClass(searchMatchingClassName);
+        $helpWindow.find(`.box-body .${searchMatchingContainerClassName}`).removeClass(searchMatchingContainerClassName);
+
+        const excludeContainerNodeTypes = ['THEAD', 'TBODY', 'TFOOT', 'TR', 'UL', 'OL', 'DL'];
+        $helpWindow.find('.box-body details').find('summary, p, th, td, dt, dd, h3, h4, h5, h6').each(
+            function (_, node) {
+              const $node = $(node);
+              const nodeText = normalizeText($node.text());
+
+              if (!nodeText.includes(searchText)) {
+                return;
+              }
+
+              $node.addClass(searchMatchingClassName);
+
+              {
+                let $current = $node.parent();
+                while (
+                    !$current.hasClass('box-body') &&
+                    !$current.hasClass(searchMatchingClassName) &&
+                    !$current.hasClass(searchMatchingContainerClassName)
+                    ) {
+                  if (!excludeContainerNodeTypes.includes($current[0].nodeName)) {
+                    $current.addClass(searchMatchingContainerClassName);
+                    if ($current[0].nodeName === 'DETAILS') {
+                      $current.attr('open', '');
+                    }
+                  }
+                  $current = $current.parent();
+                }
+              }
+            }
+        );
+      }
+  );
+
+  $buttonToClear.on(
+      'click',
+      function () {
+        $searchTextField.val('').trigger('change');
+      }
+  );
+})($);
+
 // スマホ用 ----------------------------------------
 $(window).resize(function(){
   if(window.matchMedia('(max-width:600px)').matches){


### PR DESCRIPTION
# 目的

ヘルプ内から目的の機能を探しやすくする

- ヘルプの総量がそれなりに多く、（とくにセッション中にリアルタイムに）なにかを探すにはそれなりに大変
- ヘルプ内では `details` 要素による折りたたみがもちいられており、とくに折りたたまれている部分から探す際には必要な操作がかさむ
  - 折りたたみの内側を見落としやすいという問題もある
- ブラウザ標準の全文検索機能では代用が務まらない
  - 折りたたまれている部分が検索の対象とならない（すくなくとも Google Chrome の場合）
  - ヘルプ外も（当然）検索の対象となってしまう。「ラウンド」「ダイス」「計算」などの一般的なセッションでもちいるであろう語句で検索したい場合、しばしばチャットログ等が大量にマッチして探しづらい
  - そもそもブラウザの全文検索機能は、ライトユーザーにはあまり馴染みがない例も多いとおもわれる

# 仕様

ヘルプウィンドウの上部にあるテキスト入力欄にテキストが入力されているとき、それに一致するヘルプ項目を抽出する。

## 一致するかどうかの判定の規則

 - 部分一致（ `String.prototype.includes()` ）
 - 一般的な英数字の全角・半角を区別しない（既存の `toHalfWidth()` に準拠）
 - 大文字・小文字を区別しない（ `String.prototype.toLowerCase()` を適用した上で判定）

## 抽出の規則

- 直接に該当する要素は背景色を変える。具体的には `summary, p, th, td, dt, dd, h3, h4, h5, h6` が対象。
  - デフォルトのヘルプには含まれていない要素も対象としているが、これは次の理由による：
    - ヘルプにはユーザー定義のテキスト置換に関するものが含まれるため
    - 今後の機能追加・変更等に際してヘルプが更新されるとき、検索機能の都合を（ほとんど）意識しなくてよいようにするため。（常識的に使いそうな要素は  `summary, p, th, td, dt, dd, h3, h4, h5, h6` くらいだろうという判断）
- 該当する要素を内包するコンテナ要素は、外縁部の色を変える。
  - ただし、 `thead, tbody, tfoot, tr, ul, ol, dl` は例外とする。
    - テーブル系は `table, th, td` が、リスト系は `li, dt, dd` が、それぞれ強調されていれば十分であると考えたため。（この除外ルールなしだと視覚的にうるさかった）
- `details` 要素は、該当する要素を内包しない場合、非表示にする。
- 該当する要素を内包する `details` 要素は、展開する。

# 動作イメージ

![ytchat_search_in_help](https://user-images.githubusercontent.com/44130782/145954281-05499467-efa6-4000-9450-fc2d5f933e70.gif)
