### PR TITLE
ログの共有メモをデフォルトで展開しておく

### DIFF
--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -253,7 +253,7 @@ foreach (<$FH>){
     next;
   }
 
-  if($system =~ /^memo/ && $info){ $info = '<details><summary>詳細</summary>'.$info.'</details>'; }
+  if($system =~ /^memo/ && $info){ $info = '<details open><summary>詳細</summary>'.$info.'</details>'; }
   
   my $class  = ($name eq '!SYSTEM') ? 'system '    : '';
      $class .= ($system =~ /^(topic|memo|bgm?|ready|round|enter|exit)/) ? "$1 " : '';


### PR DESCRIPTION
ログを読んでいる最中は、原則的にスクロール操作のみをしつづければよいのだが、折り畳みを展開するためにはクリック／タップ操作が必要になってわずらわしい。

メモの内容の量によって展開するかどうかを分岐してもよいかもしれない。
