### PR TITLE
フォルダを隔離されたログを表示している際の、過去ログ一覧のＵＩを改善

### DIFF
--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -79,7 +79,7 @@
       </details>
     </TMPL_IF><TMPL_IF LogList>
     <details <TMPL_VAR logListOpen>>
-      <summary class="bold">過去ログ</summary>
+      <summary class="bold"><TMPL_IF isIsolated><TMPL_VAR roomName>の</TMPL_IF>過去ログ</summary>
         <ul id="loglist">
 <TMPL_LOOP LogList><li><a href="./?mode=logs<TMPL_IF idDir>&id=<TMPL_VAR idDir></TMPL_IF>&log=<TMPL_VAR FILE>" data-byte="<TMPL_VAR BYTE>" <TMPL_IF CURRENT>class="bold"</TMPL_IF>><TMPL_IF NAME><span class="name"><TMPL_VAR NAME></span></TMPL_IF><TMPL_IF FILE><span class="file"><TMPL_VAR FILE></span></TMPL_IF></a>
 </TMPL_LOOP>
@@ -87,7 +87,14 @@
     </details>
     </TMPL_IF></div>
 
-    <ul id="return-link"><TMPL_UNLESS dlMode><li class="right"><a href="./"><i class="fas fa-undo-alt"></i>ルーム一覧に戻る</a></li></TMPL_UNLESS></ul>
+    <ul id="return-link">
+      <TMPL_UNLESS dlMode>
+        <TMPL_IF isIsolated>
+          <li class="right"><a href="./?mode=logs"><i class="fas fa-undo-alt"></i>ログ一覧</a></li>
+        </TMPL_IF>
+        <li class="right"><a href="./"><i class="fas fa-undo-alt"></i>ルーム一覧に戻る</a></li>
+      </TMPL_UNLESS>
+    </ul>
   </aside>
 </div>
 <div id="left">

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -39,6 +39,8 @@ foreach my $key (keys %set::rooms){
 my $error_flag = (!exists($rooms{$id}) && !$::in{'log'}) ? 1 : 0;
 
 my $logs_dir = ($id && $rooms{$id}{'logs-dir'}) ? $rooms{$id}{'logs-dir'} : $set::logs_dir;
+my $is_isolated = !($logs_dir eq $set::logs_dir);
+my $room_name = $is_isolated ? $rooms{$id}{'name'} : '';
 
 my @tabs = $id ? ($rooms{$id}{'tab'} ? @{$rooms{$id}{'tab'}} : ('メイン','サブ')) : ();
 
@@ -408,6 +410,8 @@ if($opt{'logList'}){
   $ROOM->param(LogList => \@loglist);
   $ROOM->param(idDir => $id) if($id && $rooms{$id}{'logs-dir'});
   $ROOM->param(logListOpen => $::in{'log'} ? 'open' : '');
+  $ROOM->param(isIsolated => $is_isolated);
+  $ROOM->param(roomName => $room_name);
 }
 
 


### PR DESCRIPTION
下記二点の改善

* フォルダを隔離されたログを表示しているときは「過去ログ一覧」の内容がそのフォルダのものに置き換わるが、ＵＩ上で置き換わっていることがわからない。
* フォルダを隔離されたログを表示しているとき、（隔離されていない）ログ一覧ページに直接飛べる導線がない。

![image](https://user-images.githubusercontent.com/44130782/193801497-fae30ac2-662d-415b-8798-c78a1ed17253.png)
