### PR TITLE
共有メモの拡大表示

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -99,6 +99,41 @@ html,body {
   color: #f00;
 }
 
+/* モーダル */
+dialog.modal {
+  margin: auto;
+  box-sizing: border-box;
+  min-width: 25vw;
+  max-width: 45vw;
+  min-height: 25vh;
+  max-height: 65vh;
+  z-index: 20;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4rem;
+  padding: 4rem;
+  background-color: rgb(0, 16, 32);
+}
+dialog.modal::backdrop {
+  background: hsl(0 0% 80% / 0.5);
+}
+dialog.modal[open] {
+  display: flex;
+}
+dialog.modal > .dialog-inner {
+  max-height: calc(35vh - (4rem * 2));
+  width: auto;
+  height: auto;
+  overflow-y: auto;
+  background: none;
+  box-shadow: none;
+}
+dialog.modal > .dialog-inner > .content-area {
+  color: white;
+  line-height: 1.4;
+}
+
 /* // トピック
 ---------------------------------------------------------------------------------------------------- */
 #topic {
@@ -406,6 +441,7 @@ html,body {
   text-align: left;
   line-height: 1.6;
   overflow: auto;
+  cursor: zoom-in;
 }
 .sheet .sheet-memo-body #memo-view:empty::before {
   content: 'メモがありません';

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1152,6 +1152,20 @@ function memoSelect(num){
   sheetOpen();
   autosizeUpdate(memoValue);
 }
+(() => {
+  const modal = createModal();
+  modal.addClass('logs');
+
+  const memoViewNode = document.getElementById('memo-view');
+  memoViewNode.addEventListener(
+      'click',
+      () => {
+        const memoContainer = document.createElement('div');
+        memoContainer.innerHTML = memoViewNode.innerHTML;
+        modal.open(memoContainer);
+      }
+  );
+})();
 function memoModeChange(type){
   document.getElementById('sheet-unit-memo').dataset.memoMode = type;
   autosizeUpdate(document.getElementById("sheet-memo-value"));
@@ -2107,6 +2121,58 @@ document.querySelectorAll('.float-box > h2').forEach(obj => {
     box.style.right = 'auto';
   }
 });
+
+// モーダル
+function createModal(...contentNodes) {
+  function Modal(dialogNode) {
+    this._dialogNode = dialogNode;
+  }
+  Modal.prototype.addClass = function(...classNames) {
+    this._dialogNode.classList.add(...classNames);
+  };
+  Modal.prototype.replaceContent = function(...contentNodes) {
+    const contentNode = this._dialogNode.querySelector('.dialog-inner > .content-area');
+    contentNode.innerHTML = '';
+    contentNodes.forEach(x => contentNode.append(x));
+  };
+  Modal.prototype.open = function (...contentNodes) {
+    this._dialogNode.showModal();
+
+    if (contentNodes.length > 0) {
+      this.replaceContent(...contentNodes);
+    }
+  };
+  Modal.prototype.close = function () {
+    this._dialogNode.close();
+  };
+
+  const contentArea = document.createElement('div');
+  contentArea.classList.add('content-area');
+
+  const dialogInnerNode = document.createElement('div');
+  dialogInnerNode.classList.add('dialog-inner', 'box');
+  dialogInnerNode.append(contentArea);
+
+  const dialogOuterNode = document.createElement('dialog');
+  dialogOuterNode.classList.add('modal');
+  dialogOuterNode.append(dialogInnerNode);
+
+  document.querySelector('body').append(dialogOuterNode);
+
+  const modal = new Modal(dialogOuterNode);
+  modal.replaceContent(...contentNodes);
+
+  dialogOuterNode.addEventListener(
+      'click',
+      event => {
+        if (event.target === dialogOuterNode) {
+          modal.close();
+        }
+      }
+  );
+
+  return modal;
+}
 
 // スマホ用 ----------------------------------------
 window.addEventListener('resize', () => {


### PR DESCRIPTION
# 機能

共有メモを一時的に拡大（というか大きなスペースで）表示する。

# 意図

現状の共有メモは、画面隅のごく狭い幅で表示される。
しかし、メモ内に一定以上の長いセンテンスや長いテキストがあると、この狭い幅では読みづらい。

この問題を解消するための、一時的に大きなスペースで表示する機能を追加する。

# 仕様

共有メモの文面をクリックすると、モーダルで大きなスペースでの表示がされる。

# 動作イメージ

![zoom_memo](https://user-images.githubusercontent.com/44130782/193889738-90a7e0bb-b0a7-41d7-adfc-148531e90e28.gif)
