### PR TITLE
共有メモを追加したときに、追加したメモを選択した状態にする

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -481,7 +481,7 @@ let tabLogLinage = {};
 let beforeLastnumber = 0;
 let loadedLog = 0;
 let rawLogs = {};
-function logGet(){
+function logGet(onCompleted = null){
   console.log('logGet');
   if(lock) return 0;
   lock = 1;
@@ -917,6 +917,9 @@ function logGet(){
   })
   .finally(data => {
     lock = 0;
+    if (onCompleted instanceof Function) {
+      onCompleted();
+    }
   });
 }
 // 文字装飾 ----------------------------------------
@@ -1227,7 +1230,7 @@ function readyCheckSet(){
 }
 
 // 送信 ----------------------------------------
-function commSend(comm,tab,name,color,address,bcdice){
+function commSend(comm,tab,name,color,address,bcdice,onCompleted=null){
   if(romMode){ return alert('見学入室では送信できません'); }
   if(name === undefined){ return alert('送信する名前がありません'); }
   if(comm === '' || comm === undefined){ return alert('送信するテキストがありません'); }
@@ -1263,7 +1266,9 @@ function commSend(comm,tab,name,color,address,bcdice){
     if(data['status'] === 'error'){
       alert(data['text']);
     }
-    else { logGet(); }
+    else {
+      logGet(onCompleted);
+    }
   })
   .catch(error => {
     console.error('発言の送信に失敗: ', error);
@@ -1544,7 +1549,11 @@ function roundSubmit(num){
 function memoSubmit(){
   const num = (selectedMemo === '') ? '' : Number(selectedMemo)+1;
   let comm  = '/memo' + num + ' ' + document.getElementById("sheet-memo-value").value;
-  commSend(comm,0,nameList[0]['name']);
+  commSend(comm,0,nameList[0]['name'],null,null,null,() => {
+    if (num === '') {
+      memoSelect(parseInt(document.querySelector(`#memo-list li[data-num]:last-child`).dataset.num) - 1);
+    }
+  });
 }
 // BGM更新送信 ----------------------------------------
 function bgmSubmit(){


### PR DESCRIPTION
# 従来の問題

従来の実装では、メモを追加した時点ではメモが選択されていない（依然として追加するコンテクストのままである）。
そのため、「追加直後の更新・削除」が直感に反する（そして既存のメモに対する更新・削除と一貫しない）ふるまいをする。

## 追加直後に更新しようとすると、別のメモとして追加されてしまう例
![edit_memo_immediately_after_added](https://user-images.githubusercontent.com/44130782/194613579-c7ed0824-e507-40fa-b182-1ba1f14635a1.gif)

## 追加直後に削除しようとすると、（空のメモを追加しようとしたあつかいとなって）アラートが発生してしまう例
![delete_memo_immediately_after_added](https://user-images.githubusercontent.com/44130782/194613687-296c9226-4c2d-43eb-9e39-ada20cca0d51.gif)

# 新仕様

メモを追加したとき、最後に追加されたメモを選択する。

## 想定される課題

「追加の結果を取得するリクエストが終わった時点での最後のメモを選択する」という挙動なので、複数人がほぼ同時にメモを追加しようとした場合（または通信状況がいちじるしくわるい場合など）、自分が直前に追加したものとは異なるメモが選択される可能性はある。
