### PR TITLE
ゆとシートⅡ以外からもユニットを自動入力できるようにする - ステータス自動入力のための URL を対象の文書（ HTML ）から得るように

### DIFF
--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -192,7 +192,7 @@
           <dt>ステータス</dt><dd><textarea class="autosize" id="new-unit-stt-value"><TMPL_VAR newUnitSttDefault></textarea></dd>
         </dl>
         <ul>
-          <li><label><input type="checkbox" id="new-unit-urlload"><b>URLからステータスを自動入力</b></label><br><span>（※ゆとシートⅡのみ）</span></li>
+          <li><label><input type="checkbox" id="new-unit-urlload"><b>URLからステータスを自動入力</b></label><br><span>（※対応しているサイトのみ）</span></li>
           <li><label><input type="checkbox" id="new-unit-addname"><b>名前欄にも追加する</b></label></li>
         </ul>
         <button onclick="newUnitSubmit();">作成</button>


### PR DESCRIPTION
https://github.com/yutorize/ytsheet2/pull/35 を前段とする。

----

# 目的

ゆとシート以外からも自動入力できるようにする。

# 方針

そのために「指定された“参照URL”に対し、どのURLにアクセスすれば必要な情報が得られるか」を規格化し、対象の文書自体から得る。

# 仕様

* `<link rel="ytchat-body-exporting-point" type="application/json" href="...">` がメインの JSON の取得先（ `characterName`, `sheetDescriptionM`, `memo`, `unitStatus`, `image*` を得る）
  * 必須。
* `<link rel="ytchat-palette-exporting-point" type="text/plain" href="...">` がチャットパレットの取得先
  * 任意。存在しない場合はチャットパレットの内容が空文字列に等しいものとしてふるまう。

# 動作イメージ

* １体めのユニットはゆとシートⅡから
* ２体めのユニットは[「ストリテラ　アシスタンスツール」](https://s-ammit.sakura.ne.jp/storyteller/)から

それぞれ取り込んでいる。

![import_unit_from_sheet](https://user-images.githubusercontent.com/44130782/195754316-78e641f5-e021-48b8-a5a4-819dad8266ed.gif)
