### PR TITLE
ユニット一覧から簡易的にステータスを増減させる機能を追加

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -305,6 +305,10 @@ html,body {
   display: none;
 }
 
+#status #status-body > dl[data-name] > dd[data-manipulation-allowed="yes"] {
+  cursor: pointer;
+}
+
 #status .add.button {
   position: absolute;
   bottom: .1em;
@@ -548,6 +552,44 @@ body.rom .sheet { display: none; }
   width: max-content;
   margin-left: auto;
 }
+
+.status-manipulator {
+  display: block;
+  padding: 0.75rem;
+  margin: 0;
+  position: fixed;
+  z-index: 5;
+  right: 1rem;
+  width: calc(((0.75rem + 1px) * 2) + ((3rem + 0.5rem) * 5));
+  height: auto;
+  max-height: 90vh;
+  background-color: rgba(4, 1, 27, 0.85);
+  border: 1px solid black;
+  border-radius: 0.7em;
+  font-size: xx-small;
+}
+.status-manipulator .manipulation {
+  margin: 0 0.5rem 0.5rem 0;
+  text-align: right;
+  padding: 0.5em;
+  border-radius: 0.3em;
+  cursor: pointer;
+  float: left;
+  width: 3rem;
+}
+.status-manipulator .manipulation:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+.status-manipulator .manipulation[data-token^="+"] {
+  color: #92cde2;
+}
+.status-manipulator .manipulation[data-token^="-"] {
+  color: #ebad73;
+}
+.status-manipulator .manipulation[data-token="+1"], .status-manipulator .manipulation[data-token="-1"] {
+  clear: left;
+}
+
 /* パレット */
 .sheet-body .chat-palette-area {
   position: relative;

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1187,7 +1187,7 @@ function statusUpdate () {
         isNumeric = false;
       }
       else if (value && value.match(/^-?[0-9]+\/[0-9]+$/)){
-        const [now, max] = value.split("/");
+        const [now, max] = value.split("/").map(Number);
         let per = (now / max) * 100;
         const signal = (per >= 75) ? 'safe'
                      : (per >= 50) ? 'caution'

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1069,6 +1069,76 @@ function topicChange (topicValue){
   document.getElementById("topic-value").innerHTML = tagConvert(rawTopic);
 }
 // ステータス表更新 ----------------------------------------
+function openManipulation(event) {
+  const statusContainer = event.path.find(x => x.hasAttribute('data-manipulation-tokens'));
+  if (statusContainer == null) {
+    return;
+  }
+  const tokens = statusContainer.dataset.manipulationTokens.split(',');
+  if (tokens.length === 0) {
+    return;
+  }
+
+  const unitName = statusContainer.parentNode.dataset.name;
+  const statusName = statusContainer.dataset.stt;
+
+  const documentBody = document.querySelector('body');
+
+  const statusContainerBounds = statusContainer.getBoundingClientRect();
+
+  const manipulator = document.createElement('ul');
+  manipulator.classList.add('status-manipulator');
+  documentBody.append(manipulator);
+  manipulator.style.left = `calc(${statusContainerBounds.right}px - 4.00em)`;
+  manipulator.style.top = `calc(${statusContainerBounds.bottom}px + 0.25em)`;
+  {
+    const manipulatorBounds = manipulator.getBoundingClientRect();
+    const windowWidth = window.innerWidth;
+    if (manipulatorBounds.right > windowWidth) {
+      manipulator.style.left = `calc(${statusContainerBounds.right}px - 4.00em - ${manipulatorBounds.right - windowWidth}px)`;
+    }
+  }
+
+  const manipulatorRemover = () => {
+    if (manipulator.parentNode != null) {
+      manipulator.parentNode.removeChild(manipulator);
+    }
+
+    documentBody.removeEventListener('click', manipulatorRemover);
+  };
+
+  for (const token of tokens) {
+    const manipulationItem = document.createElement('li');
+    manipulationItem.classList.add('manipulation');
+    manipulationItem.textContent = token;
+    manipulationItem.dataset.token = token;
+    manipulationItem.addEventListener(
+        'click',
+        (token => {
+          return () => {
+            const command = `${unitName}@${statusName}${token}`;
+            {
+              const temporaryNode = document.createElement('textarea');
+              const temporaryNodeId = 'status-manipulator-form';
+              temporaryNode.setAttribute('id', temporaryNodeId);
+              temporaryNode.style.display = 'none';
+              temporaryNode.value = command;
+
+              documentBody.append(temporaryNode);
+
+              formSubmit(temporaryNodeId, unitName);
+
+              temporaryNode.parentNode.removeChild(temporaryNode);
+            }
+            manipulatorRemover();
+          };
+        })(token)
+    );
+
+    manipulator.append(manipulationItem);
+  }
+  setTimeout(() => documentBody.addEventListener('click', manipulatorRemover), 0);
+}
 function statusUpdate () {
   for (let name in unitList) {
     const id = unitList[name]['id'];
@@ -1092,11 +1162,29 @@ function statusUpdate () {
           document.querySelector(`#stt-unit-${id} > dt`).insertAdjacentHTML('afterend',add);
         }
       }
+      const valueContainer = document.querySelector(`#stt-unit-${id} [data-stt="${stt}"]`);
       const valueNum = document.querySelector(`#stt-unit-${id} [data-stt="${stt}"] .value`);
       const valueGauge = document.querySelector(`#stt-unit-${id} [data-stt="${stt}"] .gauge`);
       const valueGaugeNow = document.querySelector(`#stt-unit-${id} [data-stt="${stt}"] .gauge i`);
+      let isNumeric;
+      let manipulationTokens;
+      /** @return {int[]} */
+      function makeRange(start, end) {
+        const range = [];
+        if (start < end) {
+          for (let i = start; i <= end; i++) {
+            range.push(i);
+          }
+        } else {
+          for (let i = start; i >= end; i--) {
+            range.push(i);
+          }
+        }
+        return range;
+      }
       if(value && value.match(/&nbsp;|\s/)){
         valueNum.innerHTML = '<span>'+value.split(/&nbsp;|\s/).join('</span> <span>', )+'</span>';
+        isNumeric = false;
       }
       else if (value && value.match(/^-?[0-9]+\/[0-9]+$/)){
         const [now, max] = value.split("/");
@@ -1112,6 +1200,11 @@ function statusUpdate () {
           valueGauge.classList.remove('none');
           gaugeUpdate(valueGauge,valueGaugeNow,per,signal);
         }
+
+        isNumeric = true;
+        manipulationTokens =
+          (now < max ? makeRange(1, max - now).slice(0, 30) : [])
+            .concat((now > 0 ? makeRange(-1, -now).slice(0, 30) : []));
       }
       else if (stt === '侵蝕' && value){
         const per = (value / 200) * 100;
@@ -1125,8 +1218,21 @@ function statusUpdate () {
           valueGauge.classList.remove('none');
           gaugeUpdate(valueGauge,valueGaugeNow,per,signal);
         }
+
+        isNumeric = true;
+        manipulationTokens = makeRange(1, 30);
       }
-      else { valueNum.innerHTML = value; valueGauge.classList.add('none'); }
+      else {
+        valueNum.innerHTML = value;
+        valueGauge.classList.add('none');
+
+        if ((isNumeric = /^-?\d+$/.test(value))) {
+          const now = parseInt(value);
+          manipulationTokens =
+            makeRange(1, Math.max(20, Math.ceil(now / 2))).slice(0, 30)
+              .concat(makeRange(-1, Math.min(-20, -Math.ceil(now / 2))).slice(0, 30));
+        }
+      }
       // 値が入ってない項目は非表示
       const sttObj = document.querySelector(`#stt-unit-${id} [data-stt="${stt}"]`);
       if(!value && value !== 0){
@@ -1135,6 +1241,17 @@ function statusUpdate () {
       else {
         sttObj.style.display = '';
         viewCount++;
+      }
+
+      valueContainer.removeEventListener('click', openManipulation);
+
+      if (isNumeric && manipulationTokens != null) {
+        valueContainer.dataset.manipulationAllowed = 'yes';
+        valueContainer.dataset.manipulationTokens = manipulationTokens.map(x => x > 0 ? `+${x}` : x).join(',');
+        valueContainer.addEventListener('click', openManipulation);
+      } else {
+        valueContainer.dataset.manipulationAllowed = 'no';
+        valueContainer.dataset.manipulationTokens = '';
       }
     }
     document.querySelectorAll(`#stt-unit-${id} dd[data-stt]`).forEach(dd => {


### PR DESCRIPTION
# 機能

ユニット一覧から簡易的にステータスを増減できるＵＩ。

## 動作イメージ

![status_manipulator](https://user-images.githubusercontent.com/44130782/195861451-fd812663-2598-41db-9a5f-63b76cbde005.gif)

# 目的

* ステータスリモコンやコマンドと比較して、より直感的なインタフェースを提供する
* ステータスリモコンと比較して、ユニットを選択せずともステータスの操作ができる

すべてのケースの需要を満たせるわけではないが、大半のゲームシーンのおける大半の需要を満たせることを狙っている。

# 仕様

ユニット一覧に表示されるステータス項目のうち、数値によるものを対象とする。
対象をクリックすると、増減量を選択するポップアップが表示される。
増減量を選択すると、そのステータスにその増減量が反映される。

## “数値によるもの”

「数値によるもの」は、次のいずれかに該当するものとする。

* 最大値と現在値をもつもの
* 現在値が整数値であるもの（ `/^-?\d+$/` ）
* ステータス名が「侵蝕」であるもの（ DX3 の侵蝕値）

## 増減量の選択肢

* 最大値と現在値をもつものであれば、増加は現在値から最大値に至るまでの各値を１刻み、減少は現在値から０に至るまでの各値を１刻み。ただし、下限が－30、上限が＋30。
* 現在値が整数値であるものは、増加は＋［現在値の半分（端数切り上げ）］（最小20・最大30）まで１刻み、減少は－［現在値の半分（端数切り上げ）］（最小20・最大30）まで１刻み。
* ステータス名が「侵蝕」であるものは、＋１から＋30まで１刻み。

20 や 30 を一定の境界にしているのは、選択肢が多すぎると表示しきれないことをふまえたうえで、現行のゲームシーンで頻出する数値の範囲を意識したため。
