### PR TITLE
ランダムに割り当てられる文字色が過剰に暗くならないように

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -516,12 +516,19 @@ function npcDel(){
 // ランダムカラー
 function randomColor(){
   const l = 3;
-  const c = ['00','2b','56','81','ab','d5','ff'];
-  const cl = c.length;
-  let r = "";
-  for(var i=0; i<l; i++){
-    r += c[Math.floor(Math.random()*cl)];
-  }
+  let r;
+  let total;
+  do {
+    const c = ['00','2b','56','81','ab','d5','ff'];
+    const cl = c.length;
+    r = "";
+    total = 0;
+    for(var i=0; i<l; i++){
+      const element = c[Math.floor(Math.random()*cl)];
+      r += element;
+      total += parseInt(element, 16);
+    }
+  } while(total <= 0x2b * 3);
   return r;
 }
 // セレクトボックスにセット


### PR DESCRIPTION
# 挙動変更

文字色のランダム割り当てにおいて、暗すぎる色にならないようにする。

# 理由

視認性がひどく悪いケースがある。
とくに `#000000` を引いたケースは最悪で、選択していない場合は肉眼での視認はほとんど不可能であり、選択されていても現実的には視認困難である。

![image](https://user-images.githubusercontent.com/44130782/196227921-7c47fcfc-17a6-4d82-8242-f4882971d642.png)

# 仕様

r, g, b の総和が 0x2b*3 以下の場合は再抽選する。
（ (0x2b, 0x56, 0x56) くらいならまあ視認できるので、とりあえずこのくらいにしておく）