### PR TITLE
ログの表示モードの変更に連動して表示上のＵＲＬを変える

### DIFF
--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -61,6 +61,7 @@ document.getElementById('option-view-mode').addEventListener('change', function(
     const url = location.href.replace(/#(.+)$/,'').replace(/&type=(.+?)(&|$)/,'').replace(/&page=(.+?)(&|$)/,'') + '&type=simple';
     open(url);
     e.target.value = liteMode ? 'lite' : 'normal';
+    return;
   }
   else {
     liteMode = 0;
@@ -75,6 +76,10 @@ document.getElementById('option-view-mode').addEventListener('change', function(
     resizeObserver.observe(document.getElementById('base'));
     window.addEventListener('scroll', scrollEvent);
   }
+
+  const url = new URL(location.href);
+  url.searchParams.set('type', type);
+  history.replaceState(null, '', url.toString().replace('id=%40', 'id=@'));
 })
 
 // ページ分け ----------------------------------------


### PR DESCRIPTION
# 機能

ログの表示モードが変更されたとき、それにあわせて（表示上の）ＵＲＬを変える。

# 仕様

クエリパラメータの `type` を変更後の表示モードとして指定する。

# 実装アプローチ

ＵＲＬの生成は [`URL` クラス](https://developer.mozilla.org/ja/docs/Web/API/URL)と `location.href` の組み合わせでおこなう。

ただし、 `URL` の `.toString()` は（現行ログの場合にたいてい含まれる） `'@'` をＵＲＬエンコーディングしてしまうので、その点のみ後から置換している。
（ＵＲＬエンコーディングされてても問題なく動作はするが、元の URL からむやみに変化するのは、使用感としてきもちわるいため）

最終的な表示の変更には [`history.replaceState(...)`](https://developer.mozilla.org/ja/docs/Web/API/History/replaceState) をもちいる。

# 動機

ルームからそのルームの現行ログをひらいた場合、デフォルトで軽量モード（ `type=lite` ）が選択されている。

ここで通常モードでのログを共有したい場合、「他のフロー（ルーム一覧やログ一覧）でひらく」「ＵＲＬを手動で書き換える」などの手間が発生する。

これをより直感的かつ簡潔におこなえるようにしたい。

# 動作イメージ

![ytchat-replace_url_by_log_mode](https://user-images.githubusercontent.com/44130782/222969321-f7fb0117-8e6b-4049-a889-d3a665c47f44.gif)
