### PR TITLE
「ダブルクロス行為判定」に関するヘルプを修正

### DIFF
--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -329,8 +329,8 @@
     </p>
     <p>
       例1：「【肉体】3、〈回避〉技能1レベル、C値10の回避判定」<br>
-      　<span style="color:#ee7777;">3</span><b>R</b><span style="color:#eebb77;">10</span><span style="color:#77ee77;">+1</span>　または　<span style="color:#ee7777;">3</span><b>R</b><span style="color:#77ee77;">+1</span><span style="color:#eebb77;">@10</span>
-      例1：「【知覚】4、〈射撃〉技能5レベル、C値10。エフェクトでダイスが+2、C値が-2。侵蝕ボーナスでダイス+1」<br>
+      　<span style="color:#ee7777;">3</span><b>R</b><span style="color:#eebb77;">10</span><span style="color:#77ee77;">+1</span>　または　<span style="color:#ee7777;">3</span><b>R</b><span style="color:#77ee77;">+1</span><span style="color:#eebb77;">@10</span><br>
+      例2：「【知覚】4、〈射撃〉技能5レベル、C値10。エフェクトでダイスが+2、C値が-2。侵蝕ボーナスでダイス+1」<br>
       　<span style="color:#ee7777;">4+2+1</span><b>R</b><span style="color:#eebb77;">(10-2)</span><span style="color:#77ee77;">+5</span>　または　<span style="color:#ee7777;">4+2+1</span><b>R</b><span style="color:#77ee77;">+5</span><span style="color:#eebb77;">@10-2</span>
     </p>
   </details>


### PR DESCRIPTION
 - 「例1」がふたつあったので後者を「例2」に置き換え
 - ひとつめの例とふたつめの例の間に改行を追加