### PR TITLE
Fix: ユニット自動入力時に表示される画像がリピートされないように

### DIFF
--- a/lib/pl/convert.pl
+++ b/lib/pl/convert.pl
@@ -102,7 +102,7 @@ sub dataConvert {
       elsif($fit =~ /^percentX?$/){ $fit =         $pc{'imagePercent'}*1.3 .'%'; }
       $fit = "background-size:$fit;" if $fit;
       my $position = "background-position:$pc{imagePositionX}% $pc{imagePositionY}%;";
-      $img = "<div class=\"chara-image\" style=\"background:url($pc{'imageURL'});${fit}${position}\"></div>";
+      $img = "<div class=\"chara-image\" style=\"background-image:url($pc{'imageURL'});${fit}${position}\"></div>";
     }
     $result = ($img || '')
             . "<a href=\"${set_url}\" target=\"_blank\">".($aka?"“$aka”":'')."$name</a><br>"


### PR DESCRIPTION
　https://github.com/yutorize/ytchat-adv/commit/b66ca921b431ca55d270f2405be0b1bdba70d69e#diff-cf5605685befcec31a78046e1583e28b9075b03a4ee7700108abd3defccda78fR935 での `background-repeat: no-repeat;` が `background` 一括指定プロパティで上書きされてしまう問題の修正。