### PR TITLE
横並びレイアウト時でも共有メモにマウスオーバーしたら色を変える

### DIFF
--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -754,6 +754,9 @@ body {
   border-radius: .8em;
   font-size: 90%;
 }
+[data-layout="row"] #memo ul#memo-list li[onclick]:hover {
+  background-color: rgba(255,150,0,0.3);
+}
 
 /* // ユニットシート
 ---------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
　サイドバー縦並びレイアウトの場合、マウスオーバーした共有メモは色が変わって強調される。（次画像）

![image](https://user-images.githubusercontent.com/44130782/227112645-80d35028-440b-4bd8-9a7d-30b5ba3b03ce.png)

　他方、横並びレイアウトの場合、マウスオーバーしても何らの強調もされず、わかりづらかった。
　（ https://github.com/yutorize/ytchat-adv/commit/d7fe9c2f53558342227e055e310269ceb6fa01f9#diff-573820265cfa08cdf0fcba4a10a632b8b153f13d182b408a841982c6a1d44bf3R245, chat-layout-pc.css 752 行目あたりの `background-color` の指定が優先されてたっぽい）

　これを同様に強調されるようにする。（次画像）

![image](https://user-images.githubusercontent.com/44130782/227113027-01124577-1abe-45ad-88b7-d1050b40b6b2.png)
