### PR TITLE
Fix: 背景ノードがポインターイベントを拾わないように

### DIFF
--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -825,6 +825,7 @@ dd.bgm-title:hover + #yt-player-area,
   bottom: 0;
   background-size: cover;
   background-position: center;
+  pointer-events: none;
 }
 .bg-front {
   z-index: -1;


### PR DESCRIPTION
　一部の環境で、ログ中のテキストを選択しようとしても（背景ノード側がイベントを拾ってしまうせいで）できなかったのを解消する。

　具体的には iPhone の Google Chrome で発生した。
　（ iPhone の Safari では発生しなかった）