### PR TITLE
Fix: ステータス簡易増減が動作しない不具合を修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1114,7 +1114,19 @@ function topicChange (topicValue){
 }
 // ステータス表更新 ----------------------------------------
 function openManipulation(event) {
-  const statusContainer = event.path.find(x => x.hasAttribute('data-manipulation-tokens'));
+  function findStatusContainer(node) {
+    if (node.hasAttribute('data-manipulation-tokens')) {
+      return node;
+    }
+
+    if (node.parentNode == null) {
+      return null;
+    }
+
+    return findStatusContainer(node.parentNode);
+  }
+
+  const statusContainer = findStatusContainer(event.target);
   if (statusContainer == null) {
     return;
   }


### PR DESCRIPTION
なんか `Event` オブジェクトの `path` プロパティが存在しなくなってるっぽくて、そのせいでエラーになって処理が中断されてた。