### PR TITLE
Fix: `/ready` コマンドにまつわる説明を現在の挙動に合うように修正

### DIFF
--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -104,7 +104,7 @@
     <tr><th>@delete     </th><td>発言者と同名のユニットを削除する。</td></tr>
     <tr><th>@check          </th><td>ユニット一覧の自分の名前にチェック（✔）を入れる。<br>例: <code>@check 行動終了</code></td></tr>
     <tr><th>@uncheck         </th><td>ユニット一覧の自分の名前のチェック（✔）を外す。<br>例: <code>@uncheck まだやることあった</code></td></tr>
-    <tr><th>/ready       </th><td>「レディチェックを開始しました」の文言とともに、ユニットの✔を全て外す。</td></tr>
+    <tr><th>/ready       </th><td>「レディチェック（準備確認）」をおこなう。</td></tr>
     <tr><th>/round+数値  </th><td>ラウンド数を「数値」進める。<br>ユニットの✔は全て外れる。</td></tr>
     <tr><th>/round-数値  </th><td>ラウンド数を「数値」戻す。<br>ユニットの✔は全て外れる。</td></tr>
     <tr><th>/round=数値  </th><td>ラウンド数を「数値」にする。<br>ユニットの✔は全て外れる。</td></tr>


### PR DESCRIPTION
4659f16665d246f591d98875efdf1ed96ef800dd によって、現在ではレディチェックとユニットは無関係だが、ヘルプ内の説明が旧来のままだった。