### PR TITLE
簡易増減に対応しているステータスにマウスオーバーしたときにハイライトする

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -308,6 +308,10 @@ html,body {
 #status #status-body > dl[data-name] > dd[data-manipulation-allowed="yes"] {
   cursor: pointer;
 }
+#status #status-body > dl[data-name] > dd[data-manipulation-allowed="yes"]:hover {
+  background-color: rgba(187, 204, 238, 0.1);
+  filter: brightness(115%);
+}
 
 #status .add.button {
   position: absolute;


### PR DESCRIPTION
　ステータスは狭い範囲に小さいものが密集して表示されるものであり、なにかしら見た目に変化があるようにしないと、マウスポインターがどのステータスの上にあるのかわかりづらかった。

　ハイライトの色は https://github.com/yutorize/ytchat-adv/blob/master/lib/css/config.css#L701 を元にしてみた。