### PR TITLE
編集済マークをフェードインで表示する

### DIFF
--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -487,7 +487,7 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   text-shadow: none;
   opacity: 0.2;
   animation-name: rewrited-mark-fade-in;
-  animation-duration: 0.045s;
+  animation-duration: 0.1s;
   animation-timing-function: ease-out;
 }
 @keyframes rewrited-mark-fade-in {

--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -486,6 +486,17 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   line-height: 1;
   text-shadow: none;
   opacity: 0.2;
+  animation-name: rewrited-mark-fade-in;
+  animation-duration: 0.045s;
+  animation-timing-function: ease-out;
+}
+@keyframes rewrited-mark-fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0.2;
+  }
 }
 .logs dl dd span.rewrited::before {
   content: "\e9a2";

--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -164,6 +164,7 @@ article#contents {
   margin-left: -1rem;
 }
 .logs dl span.rewrited {
+  animation: none !important;
 }
 
 /* 挿絵 */


### PR DESCRIPTION
編集済マークがいきなり現れるとけっこうびっくりするというか、視線をうばいがちなので、フェードインで表示していくぶんマイルドにしてみる。