### PR TITLE
現行ログからルームにもどるリンクを追加

### DIFF
--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -43,7 +43,7 @@ body {
 }
 /* メイン -------------------------------------------------- */
 #base header {
-  display: flex;
+  display: block;
   flex-wrap: wrap;
   align-items: end;
   position: sticky;
@@ -62,6 +62,15 @@ body {
 #base header h2 {
   display: inline-block;
   font-size: 1em !important;
+}
+#base header .back-to-room {
+  font-size: 80%;
+  margin-bottom: 0.1em;
+}
+#base header .back-to-room::before {
+  font-family: "Material Symbols Outlined";
+  font-variation-settings: 'FILL' 1;
+  content: "\e5c4";
 }
 article#contents {
   padding-bottom: 20vh;

--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -43,9 +43,6 @@ body {
 }
 /* メイン -------------------------------------------------- */
 #base header {
-  display: block;
-  flex-wrap: wrap;
-  align-items: end;
   position: sticky;
   top: 0;
   margin: -.5rem;

--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -114,6 +114,7 @@
 </div>
 <div id="base" class="box">
   <header>
+    <TMPL_IF isPresent><a class="back-to-room" href="./?mode=room&id=<TMPL_VAR roomId>">ルームに戻る</a><br /></TMPL_IF>
     <h1><TMPL_VAR title></h1><h2><TMPL_VAR subtitle></h2>
   </header>
   <article id="contents">

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -55,6 +55,7 @@ $ROOM = HTML::Template->new(
 $ROOM->param(ver => $::ver);
 
 $ROOM->param(roomId => $id);
+$ROOM->param(isPresent => !$::in{'log'} ? 1 : 0);
 $ROOM->param(title => $rooms{$id}{'name'});
 $ROOM->param(subtitle => $::in{'log'}?$::in{'log'}:'現行ログ');
 


### PR DESCRIPTION
# 機能

現行ログの場合にかぎり、ルームにもどるためのハイパーリンクを表示する。
（現行ログでない場合、なにも表示しない）

# ユースケース

分割セッションのインターバル中などで、「ログのページは開きっぱなしだが、ルームのページは閉じている」状態から「ルームのページを開きたい」ケースがままあり、そのような場合に適切な導線を提供する。

（従来の導線は、ＵＲＬを書き換えるか、ルーム一覧を経由するか、ルームのＵＲＬそのものを入手するか、といったものしかなく、迂遠かつ不便だった）

# 画面イメージ

![image](https://user-images.githubusercontent.com/44130782/236608643-32c24e43-d413-4a8c-8216-df3e26aeda77.png)
