### PR TITLE
ダッシュの置き換えを `tagConvert()` および `tagConvertUnit()` 内でおこなうように

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -925,8 +925,6 @@ function logGet(){
 }
 // 文字装飾 ----------------------------------------
 function tagConvert (comm){
-  comm = dashSet(comm);
-
   comm = comm
     .replaceAll('<br>',"\n")
 
@@ -940,6 +938,8 @@ function tagConvert (comm){
       linkURL.push(url)
       return `<a href="<!url#${linkURL.length}>" target="_blank"><!url#${linkURL.length}></a>`
     })
+  
+  comm = dashSet(comm);
   
   comm = comm
     .replace(/&lt;hr&gt;/gi,'<hr>')
@@ -997,8 +997,6 @@ function tagConvert (comm){
   return comm.replaceAll('\n',"<br>");
 }
 function tagConvertUnit (comm){
-  comm = dashSet(comm);
-
   comm = comm
     .replaceAll('<br>',"\n")
 
@@ -1020,6 +1018,10 @@ function tagConvertUnit (comm){
       linkURL.push(url)
       return `<a href="<!url#${linkURL.length}>" target="_blank"><!url#${linkURL.length}></a>`
     })
+  
+  comm = dashSet(comm);
+
+  comm = comm
     .replace(/<!url#([0-9]+)>/gi, (all,num) => {
       return linkURL[Number(num)-1];
     })

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -781,7 +781,7 @@ function logGet(){
           if(baseComm && baseComm.parentNode.dataset.id === value['userId']){
             rawLogs[targetNum] = value['comm'];
             baseComm.dataset.date += '／'+value['date'];
-            baseComm.innerHTML = tagConvert(dashSet(value['comm']))
+            baseComm.innerHTML = tagConvert(value['comm'])
             if(userId === value['userId']){
               baseComm.innerHTML += `<button class="rewrite" onclick="rewriteOpen(${targetNum})"></button>`;
             }
@@ -824,7 +824,7 @@ function logGet(){
         if(!romMode && userId !== value['userId'] && !targetDl.classList.contains('system')){
           [soundFlag['mark'] , value['comm']] = wordMark(value['comm']);
         }
-        value['comm'] = tagConvert(dashSet(value['comm']));
+        value['comm'] = tagConvert(value['comm']);
         let newComm = document.createElement('dd');
         newComm.id = 'line-' + value['num'] + '-comm';
         newComm.classList.add('comm');
@@ -835,7 +835,6 @@ function logGet(){
         soundFlag['normal'] = 1;
       }
       if(value['info']){
-        value['info'] = dashSet(value['info']);
         let newInfo = document.createElement('dd');
         if(value['system']){
           if     (value['system'].match(/^unit/)){ newInfo.classList.add('unit'); }
@@ -926,6 +925,8 @@ function logGet(){
 }
 // 文字装飾 ----------------------------------------
 function tagConvert (comm){
+  comm = dashSet(comm);
+
   comm = comm
     .replaceAll('<br>',"\n")
 
@@ -996,6 +997,8 @@ function tagConvert (comm){
   return comm.replaceAll('\n',"<br>");
 }
 function tagConvertUnit (comm){
+  comm = dashSet(comm);
+
   comm = comm
     .replaceAll('<br>',"\n")
 


### PR DESCRIPTION
# 内容

　ダッシュを置き換える `dashSet()` とタグ等を解決する `tagConvert()` が別々に呼び出されるかたちになっていたのを、後者のなかから前者を呼び出すかたちにする。

# 背景

* `dashSet()` はつねに `tagConvert()` または `tagConvertUnit()` とセットで呼び出されていた。
* `tagConvert()` を呼び出しているうえで `dashSet()` が呼び出されていない箇所はあったが、意図されたものとは考えづらい。
  * 「タグを解決してもいいがダッシュを置き換えてはならない」というケースが現実的にあるとは思えない。（逆ならまだしも）

　例として、トピック機能が「`tagConvert()` を呼び出しているうえで `dashSet()` が呼び出されていない箇所」の例であり、ダッシュを含むテキストを指定すると次のような見た目になっていた。（フォントにもよるかもしれないが、ダッシュが途切れて見える）

![image](https://user-images.githubusercontent.com/44130782/236774640-574753c1-4ee8-4674-a55c-980c8dcec35b.png)
