### PR TITLE
レディチェック時のメッセージを指定できるように

### DIFF
--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -321,6 +321,10 @@ img.icon { width: 1em; height: 1em; }
   display: flex;
   align-items: center;
 }
+.logs dl.system.ready dd .ready-check-message {
+  font-weight: normal;
+  margin-left: 0.25em;
+}
 
 .logs dl dd button {
   vertical-align: middle;

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -1985,6 +1985,9 @@ body.rom .input-form { display: none !important; }
 
 /* レディチェック */
 #ready-check h2::before { content: "\e6b1"; }
+#ready-check > .message:empty {
+  display: none;
+}
 #ready-check button[name^="ready-"] {
   display: inline-flex;
   align-items: center;

--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -105,7 +105,8 @@
     <tr><th>@delete     </th><td>発言者と同名のユニットを削除する。</td></tr>
     <tr><th>@check          </th><td>ユニット一覧の自分の名前にチェック（✔）を入れる。<br>例: <code>@check 行動終了</code></td></tr>
     <tr><th>@uncheck         </th><td>ユニット一覧の自分の名前のチェック（✔）を外す。<br>例: <code>@uncheck まだやることあった</code></td></tr>
-    <tr><th>/ready       </th><td>「レディチェック（準備確認）」をおこなう。</td></tr>
+    <tr><th>/ready       </th><td rowspan="2">「レディチェック（準備確認）」をおこなう。<br>メッセージを指定した場合、その文面とともにレディチェックをおこなう。<br>例： <code>/ready 割り込み行動のないひとはチェックしてください</code></td></tr>
+    <tr><th>/ready メッセージ</th></tr>
     <tr><th>/round+数値  </th><td>ラウンド数を「数値」進める。<br>ユニットの✔は全て外れる。</td></tr>
     <tr><th>/round-数値  </th><td>ラウンド数を「数値」戻す。<br>ユニットの✔は全て外れる。</td></tr>
     <tr><th>/round=数値  </th><td>ラウンド数を「数値」にする。<br>ユニットの✔は全て外れる。</td></tr>

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -733,6 +733,7 @@
   
   <div class="float-box" id="ready-check">
     <h2>レディチェック（準備確認）</h2>
+    <p class="message"></p>
     <p class="center">
       <button onclick="readyCheckSubmit(1)" name="ready-ok">準備ＯＫ！</button>
       <button onclick="readyCheckSubmit(0)" name="ready-no">まだ待って</button>

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -760,10 +760,15 @@ function logGet(){
           if     (value['system'].match(/ok/)){ memberReady[value['userId']] = 'ok'; }
           else if(value['system'].match(/no/)){ memberReady[value['userId']] = 'no'; }
           else {
+            let message = value['comm'].substring(0, value['comm'].lastIndexOf(`by ${memberList[value['userId']]['name']}`)).trim();
+            if (message === 'レディチェックを開始') {
+              message = null;
+            }
             memberReady = {};
             memberReady[value['userId']] = 'ok';
             readyStartTab = value['tab'];
-            value['comm'] = `<button onclick="boxOpen('ready-check')">レディチェックを開始</button> by ${memberList[value['userId']]['name']}`;
+            setReadyCheckMessage(message);
+            value['comm'] = `<button onclick="openReadyCheckWindow(${message ? `'${btoa(encodeURI(message))}'` : ''})">レディチェックを開始</button>${message ? `<span class="ready-check-message">${message}</span>` : ''} by ${memberList[value['userId']]['name']}`;
           }
           readyCheckSet(loadedLog);
         }

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1175,6 +1175,20 @@ function memoShowModal(){
   });
 }
 
+// レディチェック ----------------------------------------
+function setReadyCheckMessage(message) {
+  document.querySelector('#ready-check > .message').textContent = message ?? '';
+}
+function openReadyCheckWindow(encodedMessage = null) {
+  setReadyCheckMessage(
+      encodedMessage != null && encodedMessage !== ''
+          ? decodeURI(atob(encodedMessage))
+          : null
+  );
+
+  boxOpen('ready-check');
+}
+
 // タブ ----------------------------------------
 // タブグループ追加
 function tabGroupAdd(groupNum){

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -215,7 +215,7 @@ else {
     $::in{'comm'} = "タブ「$1」を「$2」に変更しました。by $::in{'player'}";
     $::in{'tab'} = $num;
   }
-  #レディチェック
+  # レディチェック ----------
   elsif($::in{'comm'} =~ s<^/ready(?:\s(.+)$|$)><>i){
     my $message = defined($1) ? $1 : "レディチェックを開始";
     $::in{'name'} = "!SYSTEM";

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -223,9 +223,10 @@ else {
     delete $::in{'address'};
   }
   #レディチェック
-  elsif($::in{'comm'} =~ s<^/ready(?:\s|$)><>i){
+  elsif($::in{'comm'} =~ s<^/ready(?:\s(.+)$|$)><>i){
+    my $message = defined($1) ? $1 : "レディチェックを開始";
     $::in{'name'} = "!SYSTEM";
-    $::in{'comm'} = "レディチェックを開始 by $::in{'player'}";
+    $::in{'comm'} = "$message by $::in{'player'}";
     $::in{'system'} = "ready";
     delete $::in{'color'};
     delete $::in{'address'};


### PR DESCRIPTION
# 機能

「レディチェック」時にメッセージを明示的に指定できるように。

# 仕様

* `/ready メッセージ` の形式でコマンドを実行すると、「メッセージ」部分がレディチェックに際して明示される。
* メッセージのない従来どおりの形式（つまり `/ready` のみ）の場合は、従来どおり動作する。

# 目的

「ゲーム開始前の集合時」や「一時解散からの再集合時」のような、“レディチェックのニュアンスが自明なシチュエーション”以外でのレディチェックを使いやすくする。

たとえば、「このシーンでやりたいことが終わったひとはチェックしてほしい」「このタイミングでの割り込み行動がないひとはチェックしてほしい」などのユースケースを想定している。
（このような場合、いままでは通常のチャットでの発言と併せて `/ready` をもちいていたが、同等のニュアンスをより簡潔かつ明瞭に実現できるようにしたい）

# 動作イメージ

![ytchat-ready-check-with-message](https://github.com/yutorize/ytchat-adv/assets/44130782/ec4b9630-aae9-4168-a383-026ad4e5903e)
