### PR TITLE
Fix: ログの HTML で `color: undefined` などの記述が発生しないように

### DIFF
--- a/lib/html/logs-simple.html
+++ b/lib/html/logs-simple.html
@@ -74,7 +74,7 @@
   <article id="contents">
   <div class="logs">
 <TMPL_LOOP Logs>      <dl data-user="<TMPL_VAR USER>" data-tab-name="<TMPL_VAR TABNAME>">
-        <dt style="color:<TMPL_VAR COLOR>"><TMPL_VAR NAME></dt>
+        <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF>><TMPL_VAR NAME></dt>
 <TMPL_LOOP LogsDD><TMPL_IF COMM>        <dd><TMPL_VAR COMM></dd></TMPL_IF>
 <TMPL_IF INFO>        <dd class="info <TMPL_VAR TYPE>" data-game="<TMPL_VAR GAME>"><TMPL_VAR INFO></dd></TMPL_IF></TMPL_LOOP>      </dl>
 </TMPL_LOOP>

--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -122,7 +122,7 @@
   <div class="logs logs-font">
     <TMPL_LOOP Logs>
     <dl id="line-<TMPL_VAR NUM>"<TMPL_IF CLASS> class="<TMPL_VAR CLASS>"</TMPL_IF> data-user="<TMPL_VAR USER>" data-tab="<TMPL_VAR TAB>" data-tab-name="<TMPL_VAR TABNAME>">
-      <dt style="color:<TMPL_VAR COLOR>"><TMPL_VAR NAME></dt>
+      <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF>><TMPL_VAR NAME></dt>
 <TMPL_LOOP LogsDD><TMPL_IF COMM>      <dd class="comm" data-date="<TMPL_VAR DATE>"><TMPL_VAR COMM></dd>
 </TMPL_IF><TMPL_IF INFO>      <dd class="info <TMPL_VAR TYPE>" data-date="<TMPL_VAR DATE>"<TMPL_IF GAME> data-game="<TMPL_VAR GAME>"</TMPL_IF>><TMPL_VAR INFO></dd>
 </TMPL_IF></TMPL_LOOP>    </dl>

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1454,7 +1454,7 @@ function commSend(comm,tab,name,color,address,bcdice){
     'statusDefault' : sttDefaultValues.join(' <> '),
     'player' : nameList[0]['name'],
     'name'   : name,
-    'color'  : color,
+    'color'  : color ?? '',
     'comm'   : comm,
     'bcdice' : bcdice || '',
     'userId' : userId,

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -115,6 +115,7 @@ foreach (<$FH>){
   }
   
   my ($num, $date, $tab, $name, $color, $comm, $info, $system, $user, $address) = split(/<>/, $_);
+  $color = '' if $color eq 'undefined' || $color eq 'null';
   my $userid;
   $user =~ s/<(.+?)>$/$userid = $1; '';/e;
   $user_color{$name} = $color;


### PR DESCRIPTION
# 不具合（ってほどでもない）

　`commSend()` の第４パラメータ `color` が指定されていなかった場合、 `'undefined'` （※文字列）相当になってしまう。

　指定されない具体的なケースとしては、ボタンによるラウンド操作や、タブの追加・削除操作などのログが該当する。

# 動機

　いまのところ実害らしい実害はないが、気持ちわるいので……。

# 実装

* `commSend()` 内で `color` の値をチェックし、 `null` や `undefined` なら空文字列に置き換える。（これが本命） 3a331bd916c2df2024d010f27cf8e5c55169cb91 
* color がすでに `'undefined'` や `'null'` になってしまっているログがあれば、それは空文字列相当に置き換える。（すでに発生してしまっているログに対するケア） 7024accec86e2f37d79edaf91a9324f7922284a9
* color が真値でなければ style による色の指定自体を削除する。（もともと `style="color:"` などという意味のない記述が発生していたのが、それも発生しないようになる） 4d053fc731ed66ce67c53e63094a79df88ec4bad
