### PR TITLE
Fix: 発言者カラーのランダム割り当て時に余計な `#` が含まれる不具合を修正

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -483,7 +483,7 @@ function npcSave(){
   ];
   let num = 1;
   for(let i=0; i<lines.length; i++){
-    let color = "#" + randomColor();
+    let color = randomColor();
     if(!lines[i]){ continue }
     const name = lines[i].replace(/[#＃]([0-9a-zA-Z]{6})$/, () => { color = '#'+RegExp.$1; return '' });
     newList[num] = {};

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -115,6 +115,7 @@ foreach (<$FH>){
   }
   
   my ($num, $date, $tab, $name, $color, $comm, $info, $system, $user, $address) = split(/<>/, $_);
+  $color =~ s/^#{2,}/#/;
   my $userid;
   $user =~ s/<(.+?)>$/$userid = $1; '';/e;
   $user_color{$name} = $color;

--- a/lib/pl/read.pl
+++ b/lib/pl/read.pl
@@ -27,6 +27,7 @@ foreach($reverseOn ? (reverse <$FH>) : <$FH>) {
   $_ =~ s/"/\\"/g;
   $_ =~ s/\t/\\t/g;
   my ($num, $date, $tab, $name, $color, $comm, $info, $system, $user, $address) = split(/<>/, $_);
+  $color =~ s/^#{2,}/#/;
   # 初回読込時は各タブ最大100件まで読み込む
   if(!$::in{'loadedLog'}){
     next if $tablog{$tab} > 100;


### PR DESCRIPTION
# 不具合

新規の発言者名義を追加し、その色がランダム割り当てになったとき、余計な `#` が入る。

これによって適切にカラーコードをパースできないらしく、デフォルト色の白で表示されてしまう。

また、特定のパターンで操作すると（例：上記のように名義を追加し、直後に任意の発言の発言者名をその追加した名義に変更するなど）、その（不適切な）色指定のままログに記録され、結果としてやはりデフォルト色の白で表示されてしまう。

## 再現時の動作イメージ

![ytchat-fix-random-color](https://github.com/yutorize/ytchat-adv/assets/44130782/3b928398-de0e-460a-b332-f4be869c130c)

# 実装

* 余計な `#` が含まれないように（本命） c5cf9d6272417e21e99522f26e9cac37b34210a2
* すでに発生してしまっているログへのケア a342c5a0e08d008eeff7fe4202e7ed95740d4e00
