### PR TITLE
Fix: simple モードだとログが２回出力される不具合を修正

### DIFF
--- a/lib/pl/logs.pl
+++ b/lib/pl/logs.pl
@@ -21,7 +21,7 @@ else {
   if($::in{'type'} eq 'simple'){
     print logOutput();
   }
-  if($::in{'type'} eq 'download'){
+  elsif($::in{'type'} eq 'download'){
     print logOutput();
   }
   else {


### PR DESCRIPTION
# 不具合

　「シンプル」モードでログを表示すると、ログの HTML が２回くりかえして表示される。

　……なにを言っているのかよくわからないとおもうので、 https://yutorize.2-d.jp/ytchat-adv/sample/?mode=logs&id=@uP7Zui&type=simple およびそのソースを見てください。

# 原因

　logs.pl の 22 行目と 28 行目でそれぞれ `print logOutput(...)` されていた。
