### PR TITLE
送信先が全体になっているときは「後で公開」のチェックボックスを操作できなくする

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -944,6 +944,9 @@ body.rom .input-form { display: none !important; }
   font-size: 80%;
   opacity: 0.5;
 }
+#main-form .input-form:not(.secret) .address-area label {
+  pointer-events: none;
+}
 #main-form .secret .address-area label {
   opacity: 1;
 }

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -82,7 +82,7 @@
             </div>
             <div class="address-area">
               <select id="form-address" title="発言送信先"><option value="">全員</option></select>
-              <label for="secret-openlater" title="チェックを入れると、過去ログになった時には公開されます。"><input type="checkbox" id="secret-openlater"><b>後で公開</b></label>
+              <label for="secret-openlater" title="チェックを入れると、過去ログになった時には公開されます。"><input type="checkbox" id="secret-openlater" disabled><b>後で公開</b></label>
             </div>
           </div>
           <div class="comm-area">

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -713,10 +713,17 @@ document.querySelectorAll("#form-address, #secret-openlater").forEach(obj => {
   obj.addEventListener('change', () =>{
     const obj = document.querySelector('#main-form > .input-form');
     const address = document.getElementById('form-address').value;
-    const logopen = document.getElementById('secret-openlater').checked;
+    const checkboxOpenLater = document.getElementById('secret-openlater');
+    const logopen = checkboxOpenLater.checked;
     
-    if(address){ obj.classList.add('secret'); }
-    else    { obj.classList.remove('secret'); }
+    if(address){
+      obj.classList.add('secret');
+      checkboxOpenLater.removeAttribute('disabled');
+    }
+    else{
+      obj.classList.remove('secret');
+      checkboxOpenLater.setAttribute('disabled', '');
+    }
     
     if(logopen){ obj.classList.add('openlater'); }
     else    { obj.classList.remove('openlater'); }


### PR DESCRIPTION
　非公開発言を使用しないときには「後で公開」のチェックボックスを操作できる必要が（ほとんど）ないため。

* 必要のないものを偶発的に操作してしまうとわりと不安になる
* ポインターがたまたま「後で公開」の上を通過したときに反応するのも気になる
* disabled っぽい見た目（実際は disabled ではなく opacity が 0.5 になっているだけだが）にもかかわらず上記の問題があるのでなおさら気になる