### PR TITLE
非公開発言の発言者名を変更すると宛先が（視覚的に）消失する不具合を修正

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -1134,6 +1134,9 @@ body.rom .input-form { display: none !important; }
   animation-duration: 10s;
   animation-timing-function: linear;
 }
+.chat .logs dl.secret > dt[data-target-user-name] > .target-user-name::before {
+  content: " > ";
+}
 @keyframes fadein {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -128,6 +128,9 @@ article#contents {
   margin-left: -.3em;
   padding: 0 .3em;
 }
+.logs dl.secret > dt > .target-user-name::before {
+  content: " > ";
+}
 .logs dl dd {
   position: relative;
   margin-left: .5rem;

--- a/lib/html/logs-simple.html
+++ b/lib/html/logs-simple.html
@@ -24,6 +24,9 @@
     .logs dl dt {
       font-weight: bold;
     }
+    .logs dl.secret > dt > .target-user-name::before {
+      content: " > ";
+    }
     .logs dl dd.info {
       color: #acd;
       position: relative;
@@ -73,14 +76,32 @@
   </header>
   <article id="contents">
   <div class="logs">
-<TMPL_LOOP Logs>      <dl data-user="<TMPL_VAR USER>" data-tab-name="<TMPL_VAR TABNAME>">
-        <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF>><TMPL_VAR NAME></dt>
+<TMPL_LOOP Logs>      <dl data-user="<TMPL_VAR USER>" data-user-id="<TMPL_VAR USER_ID>" data-tab-name="<TMPL_VAR TABNAME>" class="<TMPL_IF ADDRESS>secret</TMPL_IF>">
+        <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF> <TMPL_IF ADDRESS>data-target-user-id="<TMPL_VAR ADDRESS>"</TMPL_IF>><TMPL_VAR NAME></dt>
 <TMPL_LOOP LogsDD><TMPL_IF COMM>        <dd><TMPL_VAR COMM></dd></TMPL_IF>
 <TMPL_IF INFO>        <dd class="info <TMPL_VAR TYPE>" data-game="<TMPL_VAR GAME>"><TMPL_VAR INFO></dd></TMPL_IF></TMPL_LOOP>      </dl>
 </TMPL_LOOP>
   </div>
   </article>
 </div>
+<script type="application/javascript">
+  // 非公開発言の宛先解決
+  {
+    const userNames = {};
+
+    document.querySelectorAll('.logs dl.secret > dt[data-target-user-id]').forEach(
+            dt => {
+              const targetUserId = dt.dataset.targetUserId;
+              const targetUserNameNode = document.createElement('span');
+              targetUserNameNode.classList.add('target-user-name');
+              targetUserNameNode.textContent =
+                      userNames[targetUserId] ??
+                      (userNames[targetUserId] = document.querySelector(`.logs dl[data-user-id="${targetUserId}"][data-user]`)?.getAttribute('data-user') ?? '');
+              dt.appendChild(targetUserNameNode);
+            }
+    );
+  }
+</script>
 <div id="foot-area">
   <footer>
     ゆとチャadv. - <a href="https://yutorize.2-d.jp" target="_blank">ゆとらいず工房</a>

--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -121,8 +121,8 @@
   <div id="prev-button" class="center"><a class="button" onclick="pageSet('prev');">前のページ</a></div>
   <div class="logs logs-font">
     <TMPL_LOOP Logs>
-    <dl id="line-<TMPL_VAR NUM>"<TMPL_IF CLASS> class="<TMPL_VAR CLASS>"</TMPL_IF> data-user="<TMPL_VAR USER>" data-tab="<TMPL_VAR TAB>" data-tab-name="<TMPL_VAR TABNAME>">
-      <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF>><TMPL_VAR NAME></dt>
+    <dl id="line-<TMPL_VAR NUM>"<TMPL_IF CLASS> class="<TMPL_VAR CLASS>"</TMPL_IF> data-user="<TMPL_VAR USER>" data-user-id="<TMPL_VAR USER_ID>" data-tab="<TMPL_VAR TAB>" data-tab-name="<TMPL_VAR TABNAME>">
+      <dt <TMPL_IF COLOR>style="color:<TMPL_VAR COLOR>"</TMPL_IF> <TMPL_IF ADDRESS>data-target-user-id="<TMPL_VAR ADDRESS>"</TMPL_IF>><TMPL_VAR NAME></dt>
 <TMPL_LOOP LogsDD><TMPL_IF COMM>      <dd class="comm" data-date="<TMPL_VAR DATE>"><TMPL_VAR COMM></dd>
 </TMPL_IF><TMPL_IF INFO>      <dd class="info <TMPL_VAR TYPE>" data-date="<TMPL_VAR DATE>"<TMPL_IF GAME> data-game="<TMPL_VAR GAME>"</TMPL_IF>><TMPL_VAR INFO></dd>
 </TMPL_IF></TMPL_LOOP>    </dl>

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -544,7 +544,19 @@ function logGet(){
           newName.id = `line-${value['num']}-name`;
           newName.style.color = value['color'];
           newName.innerHTML = value['name'];
-          if(userId == value['userId']){ newName.setAttribute('onclick',`rewriteNameOpen(${value['num']},this.innerHTML)`); }
+          if (value['address']) {
+            const talkerName = value['name'];
+            const targetUserName = (memberList[value['address']] ?? {})['name'] ?? '';
+            newName.textContent = newName.dataset.talkerName = talkerName;
+            newName.dataset.targetUserName = targetUserName;
+            if (targetUserName !== '') {
+              const targetUserNameNode = document.createElement('span');
+              targetUserNameNode.classList.add('target-user-name');
+              targetUserNameNode.textContent = targetUserName;
+              newName.appendChild(targetUserNameNode);
+            }
+          }
+          if(userId == value['userId']){ newName.setAttribute('onclick',`rewriteNameOpen(${value['num']},${!value['address'] ? 'this.innerHTML' : 'this.dataset.talkerName'})`); }
           newLog.append(newName);
           if(value['address']){
             newLog.classList.add('secret');
@@ -777,7 +789,19 @@ function logGet(){
           const targetNum = RegExp.$1;
           const base = document.getElementById(`line-${targetNum}-name`);
           if(base && base.parentNode.dataset.id === value['userId']){
-            base.innerHTML = value['name'];
+            if (
+                base.parentNode.classList.contains('secret') &&
+                base.hasAttribute('data-target-user-name')
+            ) {
+              base.textContent = base.dataset.talkerName = value['name'];
+
+              const targetUserNameNode = document.createElement('span');
+              targetUserNameNode.classList.add('target-user-name');
+              targetUserNameNode.textContent = base.dataset.targetUserName;
+              base.appendChild(targetUserNameNode);
+            } else {
+              base.innerHTML = value['name'];
+            }
             base.style.color = value['color'];
           }
           lastnumber = value['num'];

--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -488,6 +488,23 @@ function soundOff(){
   ytPlayerArea.style.display = 'none';
 }
 
+// 非公開発言の宛先解決
+{
+  const userNames = {};
+
+  document.querySelectorAll('.logs dl.secret > dt[data-target-user-id]').forEach(
+      dt => {
+        const targetUserId = dt.dataset.targetUserId;
+        const targetUserNameNode = document.createElement('span');
+        targetUserNameNode.classList.add('target-user-name');
+        targetUserNameNode.textContent =
+            userNames[targetUserId] ??
+            (userNames[targetUserId] = document.querySelector(`.logs dl[data-user-id="${targetUserId}"][data-user]`)?.getAttribute('data-user') ?? '');
+        dt.appendChild(targetUserNameNode);
+      }
+  );
+}
+
 // ボックス透過率 ----------------------------------------
 let opacityValue = localStorage.getItem('ytchatLogsOpacity') || 0.7;
 {

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -270,9 +270,11 @@ foreach (<$FH>){
       "TAB"    => $tab,
       "TABNAME"=> $tabs[$tab-1],
       "USER"   => $user,
+      "USER_ID" => $userid,
       "NAME"   => $name,
       "COLOR"  => $color,
       "CLASS" => $class,
+      "ADDRESS" => $address || '',
       "LogsDD" => [],
       "BORDER" => ((scalar(@logs)+1) % 1000 == 0 ? 1 : 0),
     });

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -320,7 +320,6 @@ sub diceCodeCheck {
 
 # 秘話 ----------
 if($::in{'address'}){
-  $::in{'name'} .= ' > '.$::in{'addressName'};
   $::in{'address'} .= $::in{'openlater'} ? '#' : '';
 }
 


### PR DESCRIPTION
# 不具合

非公開発言をおこない、その発言者名をあとから変更すると、宛先が（視覚的に）消える。

## 再現イメージ

![ytchat-talker_name_missing](https://github.com/yutorize/ytchat-adv/assets/44130782/f15f3f49-4e53-44ef-962e-e8a13068a65c)

# 原因

宛先の表示は、（ .dat ファイルの時点で）発言者名に混ぜ込むかたちで表現されていた。

# 修正方針

.dat ファイルの時点では本来の発言者名が維持されるようにして、表示は JS で解決する。

## 備考

原因の性質上、後方互換性がない。

たとえば元が `発言者 > 宛先` と表示されていた箇所は、 `発言者 > 宛先 > 宛先` と表示されるようになる。
（ `>` で分割して復元するアプローチも考えられなくはないが、（稀であろうとはいえ）名義に `>` が含まれている場合に正確に復元することが不可能な場合がありうるので、余計なことはしないほうがよいとの判断）

あくまで表示の問題にすぎないことと、非公開発言は（1.00リリースから今日まで半年以上にわたって今回の不具合が発見されていなかったくらいには）あまり利用されていない機能だと推測されることから、ダメージは比較的軽微だと考えられる。