### PR TITLE
ゆとシートからのデータ読み込み時、名前のルビが解決できなくなっていたのを修正

### DIFF
--- a/lib/pl/convert.pl
+++ b/lib/pl/convert.pl
@@ -90,7 +90,7 @@ sub dataConvert {
     }
     @stt_name = do { my %c; grep {!$c{$_}++} @stt_name }; # 重複削除
     # 名前
-    my $aka  = rubyConvert( $pc{'aka'} );
+    my $aka  = rubyConvert( $pc{'akaRuby'} ? "｜$pc{'aka'}《$pc{'akaRuby'}》" : $pc{'aka'} );
     my $name = rubyConvert( $pc{'characterName'} || $pc{'monsterName'} );
     # プロフィール
     my $profile = textConvert($pc{'sheetDescriptionM'});

--- a/lib/pl/convert.pl
+++ b/lib/pl/convert.pl
@@ -91,7 +91,7 @@ sub dataConvert {
     @stt_name = do { my %c; grep {!$c{$_}++} @stt_name }; # 重複削除
     # 名前
     my $aka  = rubyConvert( $pc{'akaRuby'} ? "｜$pc{'aka'}《$pc{'akaRuby'}》" : $pc{'aka'} );
-    my $name = rubyConvert( $pc{'characterName'} || $pc{'monsterName'} );
+    my $name = rubyConvert( ($pc{'characterName'} ? ($pc{'characterNameRuby'} ? "｜$pc{'characterName'}《$pc{'characterNameRuby'}》" : $pc{'characterName'}) : undef) || $pc{'monsterName'} );
     # プロフィール
     my $profile = textConvert($pc{'sheetDescriptionM'});
     # 画像


### PR DESCRIPTION
　かつては解決できていたっぽいが、ゆとシート側の形式変更に追従できなかったっぽい。

　↓このへんに由来するとおもわれる

* https://github.com/yutorize/ytsheet2/commit/f0fd01102c9937e59baa6ab3c05ea5c1ee739a67
* https://github.com/yutorize/ytsheet2/commit/bee7839e7f5f106c162323f9d13330985ddbda34

　↓こういう感じになってほしい

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/18239f30-1c99-4c9d-9543-7a37b6dc28ce)

