### PR TITLE
レディチェックのＵＩにおいて、自分の回答状況をよりわかりやすく

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -2002,6 +2002,17 @@ body.rom .input-form { display: none !important; }
 #ready-check button[name="ready-no"]::before {
   content: "\e5cd";
 }
+#ready-check button[name^="ready-"].selected {
+  pointer-events: none;
+  box-shadow: none;
+  filter: grayscale(50%);
+}
+#ready-check button[name="ready-ok"].selected {
+  background: rgba(0, 255, 0, 0.8);
+}
+#ready-check button[name="ready-no"].selected {
+  background: rgba(255, 34, 0, 0.8);
+}
 #ready-list {
   width: max-content;
   margin: auto;

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -2044,6 +2044,11 @@ body.rom .input-form { display: none !important; }
   content: "\e5cd";
   color: #f20;
 }
+#ready-list li.mine::after {
+  content: "（自分）";
+  color: #ffc480;
+  font-size: 80%;
+}
 
 .mem-signal::before {
   display: inline-block;

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1429,7 +1429,7 @@ async function readyCheckSet(firstLoaded){
     max++;
     if(memberReady[key] == 'ok'){ okNum++ }
     if(memberReady[key] == 'no'){ noNum++ }
-  })
+  });
   if(max === okNum + noNum){
     const targetTab = document.getElementById("chat-logs-tab"+readyStartTab);
     let newLog = document.createElement('dl');

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1424,6 +1424,9 @@ async function readyCheckSet(firstLoaded){
     let li = document.createElement('li');
     li.dataset.id = key;
     li.classList.add(memberReady[key]);
+    if (key === userId) {
+      li.classList.add('mine');
+    }
     li.innerHTML = memberList[key]['name'];
     ul.append(li);
     max++;

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1430,6 +1430,12 @@ async function readyCheckSet(firstLoaded){
     if(memberReady[key] == 'ok'){ okNum++ }
     if(memberReady[key] == 'no'){ noNum++ }
   });
+
+  if (userId != null) {
+    document.querySelector('#ready-check button[name="ready-ok"]').classList.toggle('selected', memberReady[userId] === 'ok');
+    document.querySelector('#ready-check button[name="ready-no"]').classList.toggle('selected', memberReady[userId] === 'no');
+  }
+
   if(max === okNum + noNum){
     const targetTab = document.getElementById("chat-logs-tab"+readyStartTab);
     let newLog = document.createElement('dl');


### PR DESCRIPTION
# 内容

* 自分が回答済みの場合、回答に一致するほうのボタンを強調し、そのボタンは押せなくする（ `pointer-events: none;` ）
   * ボタンの背景色は「✓」「✕」の色をもとにしています。
* 回答リスト内で、自分の名前を強調する
  * `（自分）` 表記の文字色は[入室名強調の色](https://github.com/yutorize/ytchat-adv/blob/master/lib/css/config.css#L275)をもとにしています。

# 動機

自分の回答状況を見失うことがわりとあるため。
（とくにメンバーがたくさんいるときはありがち）

# 動作イメージ

![ytchat-ready-check-improvement](https://github.com/yutorize/ytchat-adv/assets/44130782/61d8c209-e898-4cfa-9f12-e02406937c4d)
