### PR TITLE
Fix: ルーム内において、ルビ記法の変換結果が HTML として破綻しているのを修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -962,7 +962,7 @@ function tagConvert (comm){
     .replace(/&lt;hr&gt;/gi,'<hr>')
     .replace(/(^・(?!・).+(\n|$))+/gim, listCreate)
     .replace(/(?:^(?:\|(?:.*?))+\|[hc]?(?:\n|$))+/gim, tableCreate)
-    .replace(/&lt;ruby&gt;(.+?)&lt;rt&gt;(.*?)&lt;\/ruby&gt;/gi,'<ruby>$1<rp>(</rp><rt>$2</rt><rp)</rp></ruby>')
+    .replace(/&lt;ruby&gt;(.+?)&lt;rt&gt;(.*?)&lt;\/ruby&gt;/gi,'<ruby>$1<rp>(</rp><rt>$2</rt><rp>)</rp></ruby>')
     .replace(/([♠♤♥♡♣♧♦♢]+)/gi,'<span class="trump">$1</span>')
     .replace(/:([a-z0-9_]+?):/g,'<span class="material-symbols-outlined"><i>:</i>$1<i>:</i></span>')
   


### PR DESCRIPTION
　閉じ括弧 `)` のほうの _rp_ 要素の開始タグ `<rp>` の閉じ山括弧 `>` が欠けてた