### PR TITLE
Fix: ＢＧＭや背景のタイトルにスペースが含まれていると正しくパースできない不具合を修正

### DIFF
--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -158,7 +158,7 @@ else {
     my $mode = 'resize';
     if($str =~ s/\s+mode=(resize|tiling)//){ $mode = $1 }
     my $title = '無題';
-    if($str =~ /^\s*(\S+?)\s*$/){ $title = $1 }
+    if($str =~ /^\s*(.+?)\s*$/){ $title = $1 }
     if($set::src_url_limit) {
       my $hit = 0;
       foreach my $domain (@set::src_url_list){

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -112,7 +112,7 @@ else {
     my $volume = 100;
     if($str =~ s/\s+vol=([1-9][0-9]{0,2}|0)//){ $volume = $1 }
     my $title = '無題';
-    if($str =~ /^\s*(\S+?)\s*$/){ $title = $1 }
+    if($str =~ /^\s*(.+?)\s*$/){ $title = $1 }
     #Youtube
     if($url =~ "https?://((www\.)?youtube\.com|youtu\.be)/"){
       if($url =~ /youtube\.com\/watch\?(?:.*?)v=(.+?)(?:&|$)/){


### PR DESCRIPTION
非空白文字の連続のみを認めるような正規表現になっているので、空白文字を含むタイトルはパースできない。

前後に `\s*` があってキャプチャしたい部分は `+?` で最短マッチになっているので、非空白文字に限定しなくてもいいはず。