### PR TITLE
発言編集ウィンドウを、編集対象の発言の近くで開かれるように

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -442,6 +442,40 @@ function rewriteOpen(num){
     .replace(/&gt;/g, '>')
   obj.value = setValue;
   autosizeUpdate(obj);
+
+  {
+    const window = document.getElementById('rewrite-form');
+    const sourceMessageNode = document.getElementById(`line-${num}-comm`);
+    const m = window.style.inset.match(/^[\d.]+px\s+(\S+)\s+(\S+)\s+[\d.]+px$/);
+
+    let isMain = false;
+    {
+      let node = sourceMessageNode;
+      while (node != null) {
+        if (node.classList.contains('tab-group')) {
+          isMain = node.classList.contains('main');
+          break;
+        }
+        node = node.parentNode;
+      }
+    }
+
+    if (sourceMessageNode != null) {
+      const rect = sourceMessageNode.getBoundingClientRect();
+
+      const x = isMain ? rect.left : rect.right - window.getBoundingClientRect().width;
+      const y = rect.bottom + 15;
+
+      if (m != null) {
+        window.style.inset = `${y}px ${m[1]} ${m[2]} ${x}px`;
+      } else {
+        window.style.left = `${x}px`;
+        window.style.right = 'auto';
+        window.style.top = `${y}px`;
+        window.style.bottom = 'auto';
+      }
+    }
+  }
 }
 function rewriteNameOpen(num,name){
   boxOpen('rewrite-name-form');


### PR DESCRIPTION
従来は、常に画面左下付近に開かれていた。

* 編集対象が画面の上のほうにある場合、対象の編集ボタンをクリックする操作をしてから開かれた編集ウィンドウまで、視線移動が大きい。
* 編集対象がサブタブの場合も、同様に視線移動が大きい。（サブタブは右側で、ウィンドウは左下に開かれるので）