### PR TITLE
ログ画面にキャラクターシート一覧を追加

### DIFF
--- a/lib/css/logs.css
+++ b/lib/css/logs.css
@@ -562,6 +562,10 @@ dialog.credit li {
   padding: .2em 1em;
 }
 
+#sheet-list li {
+  line-height: 300%;
+}
+
 /* 統計 -------------------------------------------------- */
 .stat-table {
   margin: 0 1em 1em;

--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -107,6 +107,7 @@
     <ul id="toc-headline"></ul>
     <ul>
       <TMPL_IF statDice><li data-lv="1"><a href="#stat-dice">出目統計</a></li></TMPL_IF>
+      <TMPL_IF SheetList><li data-lv="1"><a href="#sheet-list">キャラクターシート</a></li></TMPL_IF>
       <TMPL_IF BgmList><li data-lv="1"><a href="#bgm-list">BGMリスト</a></li></TMPL_IF>
       <TMPL_IF BgiList><li data-lv="1"><a href="#bgi-list">背景リスト</a></li></TMPL_IF>
     </ul>
@@ -143,6 +144,10 @@
 <TMPL_IF statDice><dialog id="stat-dice" class="credit">
   <h3>出目統計</h3>
   <div><TMPL_VAR statDice></div>
+</dialog></TMPL_IF>
+<TMPL_IF SheetList><dialog id="sheet-list" class="credit">
+  <h3>キャラクターシート一覧</h3>
+  <ul><TMPL_LOOP SheetList><li><a target="_blank" href="<TMPL_VAR URL>"><TMPL_VAR NAME></a></li></TMPL_LOOP></ul>
 </dialog></TMPL_IF>
 <TMPL_IF BgmList><dialog id="bgm-list" class="credit">
   <h3>BGMリスト</h3>

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -99,6 +99,7 @@ my $before_color;
 my $before_user;
 my @bgms; my %bgms;
 my @bgis; my %bgis;
+my @sheet_names; my %sheets;
 my %stat;
 my %stat_count;
 my %user_color;
@@ -175,6 +176,15 @@ foreach (<$FH>){
   }
   elsif($system =~ /^tab:([0-9]+)=(.*?)$/){
     if($2){ $tabs[$1-1] = "$2"; }
+  }
+  elsif($system =~ /^unit:.*(?:\(|\|\s+)url>(http.+?)(?:\)|\s+\|)/) {
+    my $sheetUrl = $1;
+    my $unitName = $info =~ /\[{2}(.+?)>https?.+]{2}/ ? $1 : $name;
+
+    if (!$sheets{$unitName}) {
+      push(@sheet_names, $unitName);
+      $sheets{$unitName} = $sheetUrl;
+    }
   }
 
   if(!$tabs[$tab-1]){ $tabs[$tab-1] = "タブ${tab}"; }
@@ -310,6 +320,10 @@ push(@bgm_list,{ "TITLE"  => $bgms{$_} }) foreach @bgms;
 push(@bgi_list,{ "TITLE"  => $bgis{$_} }) foreach @bgis;
 $ROOM->param(BgmList => \@bgm_list);
 $ROOM->param(BgiList => \@bgi_list);
+
+my @sheet_list;
+push(@sheet_list,{ 'NAME' => $_, 'URL' => $sheets{$_} }) foreach @sheet_names;
+$ROOM->param(SheetList => \@sheet_list);
 
 ## 出目統計
 {


### PR DESCRIPTION
# 機能

ログ画面において、そのログに登場するキャラクターシートを一覧できる機能。

# 目的

キャラクターシートの確認をしやすくする。

## 背景

ログを読むうえでキャラクターシートを把握したい、またはそもそもキャラクターシートを確認するためにログ画面を開くケースはままある。

しかし、ユニット追加前後のチャット量が多い場合など、キャラクターシート（へのリンク）を発見するのが大変なことがある。

# 仕様

ユニット追加時のログをデータソースとする。

* キャラクターシートのＵＲＬ：「参照URL」に入力されたものをそれとみなす。
* キャラクターシートの名称：
  * 自動入力の対象になっている場合、参照先にもとづいて生成された名前をキャラクターシートの名称とみなす。（ _info_ の先頭のリンクになる部分）
  * 自動入力の対象になっていない場合、ユニットの名称をキャラクターシートの名称とみなす。

もし同じ名称のユニットが複数回追加されている場合、最後のもののみを採用する。