### PR TITLE
GoogleDrive 上のアセットに `usp=drive_link` 形式の URL からでもアクセスできるように

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1731,7 +1731,7 @@ function bgmPreviewPlay(url){
     ytPreview.loadVideoById(RegExp.$1);
   }
   else {
-    if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/)){
+    if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/)){
       url = `https://drive.google.com/uc?id=` + RegExp.$1;
     }
     console.log(url);
@@ -1842,7 +1842,7 @@ function bgmHistoryUpdate(){
 // 背景 ----------------------------------------
 function bgPreview(){
   let url = document.getElementById('bg-set-url').value;
-  if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/)){
+  if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/)){
     url = `https://drive.google.com/uc?id=` + RegExp.$1;
   }
   document.getElementById('bg-set-preview').src = url;
@@ -1886,7 +1886,7 @@ function bgInputSet(url, title, mode = null){
 // 挿絵 ----------------------------------------
 function imgPreview(){
   let url = document.getElementById('image-insert-url').value;
-  if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/)){
+  if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/)){
     url = `https://drive.google.com/uc?id=` + RegExp.$1;
   }
   document.getElementById('image-insert-preview').src = url;

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -89,7 +89,7 @@ else {
   elsif($::in{'comm'} =~ s<^/insert\s+(https?://.+)><>i){
     my $url = $1;
     #Google
-    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/){
+    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/){
       $url = 'https://drive.google.com/uc?id=' . $1;
     }
     $::in{'system'} = 'image';
@@ -132,7 +132,7 @@ else {
       if(!$hit){ error('許可されていないURLです'); }
     }
     #Google
-    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/){
+    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/){
       $url = 'https://drive.google.com/uc?id=' . $1;
     }
     bgmEdit($url,$title,$volume);
@@ -168,7 +168,7 @@ else {
       if(!$hit){ error('許可されていないURLです'); }
     }
     #Google
-    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|share_link)$/){
+    if($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/){
       $url = 'https://drive.google.com/uc?id=' . $1;
     }
     bgEdit($mode,$url,$title);


### PR DESCRIPTION
# 前提

Google Drive 上でコンテキストメニューから「リンクをコピー」すると、 `usp=drive_link` 形式のＵＲＬがコピーされる。

（コンテキストメニューの「共有」 → ダイアログ内の「リンクをコピー」、とするよりも操作がすくないので、こっちのほうが便利だし使われやすい気がする）

# 変更

ＢＧＭ、背景、挿絵の各機能において、この形式のＵＲＬでもアセットにアクセスできるようにする。