### PR TITLE
Fix: ツールチップが画面右端で見切れないように

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -2170,4 +2170,8 @@ function tooltipHover(event){
   if(left < 1){ left = 1 }
   child.style.top = `calc(${event.clientY - child.offsetHeight}px - 1.5em)`;
   child.style.left = (left) + 'px';
+
+  if (child.getBoundingClientRect().right > window.innerWidth) {
+    child.style.left = Math.max((left - (child.getBoundingClientRect().right - window.innerWidth)), 1) + 'px';
+  }
 }


### PR DESCRIPTION
主に共有メモと、あとはスマートフォン向けレイアウトのときに問題があった。

# 変更前
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/8d6ba44d-99b7-4b12-bae3-21092cc3cf0d)

# 変更後
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/6bae7bf5-dad4-469a-96d7-4dd0e6cade07)
