### PR TITLE
Fix: トピックが極端に縦に長くても画面を占有しすぎないように

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -113,6 +113,8 @@ html,body {
   padding: 0 .5em 0 1.8em;
   font-size: 1.2rem;
   line-height: 1.6rem;
+  max-height: 25vh;
+  overflow-y: auto;
 }
 #topic .edit.button {
   position: absolute;


### PR DESCRIPTION
# 問題

トピックが極端に縦に長いとき、他のＵＩ（メインフォーム等）を画面外に押しやってしまって困る。

# 解決方法

トピックの高さを制限する。（それを超える場合はスクロールさせる）

## 動作イメージ

### before

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/8bf8c947-6850-4206-8fa3-303ba1b1a6e4)

### after

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/2a5cf421-4b3c-4202-9cf2-be3e8fd10ef2)
