### PR TITLE
カスタムCSS読み込み方式の変更

### DIFF
--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -14,7 +14,11 @@
       
     @import url('https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css') layer(lib);
   </style>
-  <TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>"></TMPL_IF>
+  <TMPL_IF customCSS>
+    <script>
+      document.write('<link href="<TMPL_VAR customCSS>?ver='+ new Date().getTime() +'" rel="stylesheet" media="all">');
+    </script>
+  </TMPL_IF>
   <script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
   <script src="./lib/js/ui.js?<TMPL_VAR ver>" defer></script>


### PR DESCRIPTION
現在の状態では、各ユーザーにスーパーリロード（Ctrl+F5など）を要求することになってしまうので、Ctrl+F5をせずとも最新のカスタムCSSが使用できるように読み込みにJavascriptを使用する。
（先のプルリクエストでは間違えてmasterブランチに適用しようとしたため、ブランチを修正した上で再投稿）

変更前
```html
<TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>"></TMPL_IF>
```

変更後
```html
<TMPL_IF customCSS>
  <script>
    document.write('<link href="<TMPL_VAR customCSS>?ver='+ new Date().getTime() +'" rel="stylesheet" media="all">');
  </script>
</TMPL_IF>
```