### PR TITLE
Fix: リスト記法の直後にテーブル記法があった場合に正しくパースできない不具合を修正

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -179,6 +179,8 @@ sub tagConvert {
   # 自動リンク・後処理
   $comm =~ s{<!a#([0-9]+)>}{'<a href="'.$linkURL[$1-1].'" target="_blank">'.$linkURL[$1-1].'</a>'}ge;
   
+  $comm =~ s#(</ul>)\n#$1#;
+  
   $comm =~ s#\n#<br>#gi;
   return $comm;
 }

--- a/index.cgi
+++ b/index.cgi
@@ -197,8 +197,9 @@ sub tagConvertUnit {
 sub listCreate {
   my $text = shift;
   $text =~ s/^・/<li>/gm;
+  my $needLinefeed = $text =~ /\n$/;
   $text =~ s/\n//g;
-  return "<ul>$text</ul>";
+  return "<ul>$text</ul>" . ($needLinefeed ? "\n" : '');
 }
 #テーブル
 sub tableCreate {

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1066,8 +1066,8 @@ function tagConvertUnit (comm){
   
   return comm.replaceAll('\n',"<br>");
 }
-function listCreate (text){
-  return '<ul>' + text.replace(/^・/gm,'<li>').replace(/\n/,'') + '</ul>';
+function listCreate (text, _, eol){
+  return '<ul>' + text.replace(/^・/gm,'<li>').replace(/\n/,'') + '</ul>' + (eol.match(/[\n\r]/) ? eol : '');
 }
 function tableCreate (text){
   let output = '';

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1019,6 +1019,7 @@ function tagConvert (comm){
         return linkURL[Number(num)-1];
       })
   }
+  comm = comm.replaceAll(/(<\/ul>)\n/g, '$1');
   Object.keys(tooltips).forEach(key => {
     if (!key) return;
     if(comm.match(key)){


### PR DESCRIPTION
リスト記法の直後にテーブル記法があると正しくパースできない不具合があった。
（逆は問題ない。記法の解決の順序の影響）

## テストケース

```
・ list item 1
・ list item 2
| column1-1 | column2-1 |
| column1-2 | column2-2 |
```

## 再現サンプル

https://yutorize.2-d.jp/ytchat-adv/sample/?mode=room&id=@TbTee4

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/03df520f-cde3-4a3b-b3b8-22b15e43729e)

## 備考

改行コードが失われることが原因だったので、リスト記法を解決した時点で末尾の改行コードを維持するようにした。

~~そうすると最終的に改行コードが `<br>` に変換されてよけいな空行が発生するようになったので、テーブル記法と `<hr>` 記法についてケアした。（リストの直後に置かれることがあって、そのあいだに空行が入ると据わりがわるいのは、とりあえずこれくらいだとおもう）~~

~~ごちゃごちゃしてるけど正規表現＋置換でやるかぎりこのへんが限界かな～～～という念。~~