### PR TITLE
共有メモを削除するボタンを追加

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -409,9 +409,20 @@ html,body {
   font-size: 90%;
   line-height: 1.4;
 }
-.sheet .sheet-memo-body > button {
+.sheet .sheet-memo-body > .buttons {
   grid-row: 3;
-  margin: 0 calc(50% - 5em);
+  width: 100%;
+  margin: 0 auto;
+  text-align: right;
+
+  & button.to-write {
+    width: 10em;
+    margin-right: 0.5em;
+  }
+
+  & button.to-remove {
+    background: rgb(161, 14, 68);
+  }
 }
 .sheet .sheet-memo-body #memo-view {
   grid-row: 2;
@@ -433,7 +444,7 @@ html,body {
   margin-top: 0;
 }
 .sheet[data-memo-mode="view"] .sheet-memo-body .sheet-memo-outline,
-.sheet[data-memo-mode="view"] .sheet-memo-body  > button        { display: none; }
+.sheet[data-memo-mode="view"] .sheet-memo-body  > .buttons      { display: none; }
 .sheet[data-memo-mode="edit"] .sheet-memo-body #memo-view { display: none; }
 body.rom .sheet#sheet-unit-memo { display: grid; }
 body.rom .sheet#sheet-unit-memo textarea { pointer-events : none; }

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -424,8 +424,14 @@ html,body {
     margin-left: 0.5em;
   }
 }
+#sheet-unit-memo[data-num="new"] .sheet-memo-body > .buttons button.to-write::after {
+  content: "追加";
+}
 #sheet-unit-memo[data-num="new"] .sheet-memo-body > .buttons button.to-remove {
   display: none;
+}
+#sheet-unit-memo:not([data-num="new"]) .sheet-memo-body > .buttons button.to-write::after {
+  content: "更新";
 }
 .sheet .sheet-memo-body #memo-view {
   grid-row: 2;

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -417,12 +417,15 @@ html,body {
 
   & button.to-write {
     width: 10em;
-    margin-right: 0.5em;
   }
 
   & button.to-remove {
     background: rgb(161, 14, 68);
+    margin-left: 0.5em;
   }
+}
+#sheet-unit-memo[data-num="new"] .sheet-memo-body > .buttons button.to-remove {
+  display: none;
 }
 .sheet .sheet-memo-body #memo-view {
   grid-row: 2;

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -210,7 +210,7 @@
         <div class="sheet-memo-outline"><textarea id="sheet-memo-value" class="autosize"></textarea></div>
         <div id="memo-view" class="logs"></div>
         <div class="buttons">
-          <button class="to-write" onclick="memoSubmit();">追加／更新</button>
+          <button class="to-write" onclick="memoSubmit();"></button>
           <button class="to-remove" onclick="memoSubmitToRemove()">削除</button>
         </div>
       </div>

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -209,7 +209,10 @@
         </ul>
         <div class="sheet-memo-outline"><textarea id="sheet-memo-value" class="autosize"></textarea></div>
         <div id="memo-view" class="logs"></div>
-        <button onclick="memoSubmit();">追加／更新</button>
+        <div class="buttons">
+          <button class="to-write" onclick="memoSubmit();">追加／更新</button>
+          <button class="to-remove" onclick="memoSubmitToRemove()">削除</button>
+        </div>
       </div>
       <span class="close button" onclick="sheetClose();">×</span>
     </div>

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1796,10 +1796,24 @@ function roundSubmit(num){
   commSend(comm,0,nameList[0]['name']);
 }
 // メモ更新送信 ----------------------------------------
-function memoSubmit(){
-  const num = (selectedMemo === '') ? '' : Number(selectedMemo)+1;
-  let comm  = '/memo' + num + ' ' + document.getElementById("sheet-memo-value").value;
+function getSelectedMemoNum() {
+  return (selectedMemo === '') ? '' : Number(selectedMemo)+1;
+}
+function memoSubmitCore(content) {
+  const num = getSelectedMemoNum();
+  let comm = '/memo' + num + ' ' + (content ?? '');
   commSend(comm,0,nameList[0]['name']);
+}
+function memoSubmit() {
+  memoSubmitCore(document.getElementById("sheet-memo-value").value);
+}
+// メモ削除送信 ----------------------------------------
+function memoSubmitToRemove() {
+  if (!confirm(`共有メモ #${getSelectedMemoNum()} を削除しますか？`)) {
+    return;
+  }
+
+  memoSubmitCore('');
 }
 // BGM更新送信 ----------------------------------------
 function bgmSubmit(){

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1183,7 +1183,9 @@ function memoSelect(num){
   const memoView = document.getElementById("memo-view");
   memoValue.value    = shareMemo[num] ? htmlUnEscape(shareMemo[num]) : '';
   memoView.innerHTML = shareMemo[num] ? tagConvert(shareMemo[num]) : '';
-  document.querySelector('#sheet-unit-memo h2').dataset.num = num === '' ? 'new' : Number(num)+1;
+  const numText = num === '' ? 'new' : (Number(num)+1).toString();
+  document.querySelector('#sheet-unit-memo h2').dataset.num = numText;
+  document.getElementById('sheet-unit-memo').dataset.num = numText;
   document.getElementById('sheet-unit-memo').dataset.memoMode = shareMemo[num] ? 'view' : 'edit';
   sheetSelect('memo');
   selectedMemo = num;


### PR DESCRIPTION
# 機能

共有メモを削除するためのボタンを追加。

“追加（新規作成）時は削除ボタンを表示しない”ようにするついでに、「追加／更新」ボタンのラベルを追加時と更新時で切り替えるようにした。（下の「動作イメージ」には反映されていない）

# 背景

今までもメモの内容を空にしてから「追加／更新」ボタンをクリックすることで削除できたが、これは削除という目的に対して直感的な操作ではない。

# 動作イメージ

![ytsheet-button_to_remove_memo](https://github.com/yutorize/ytchat-adv/assets/44130782/f431615c-c57b-490b-ae7a-eb75e68b3404)
