### PR TITLE
Fix: ツールチップを適用するテキスト内に特殊記法がある場合のエラーを修正

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -2219,7 +2219,7 @@ window.addEventListener('resize', () => {
 
 // ツールチップ ----------------------------------------
 function tooltipHover(event){
-  const obj = event.target;
+  const obj = event.target.classList.contains('tooltip') ? event.target : event.target.closest('.tooltip');
   const child = obj.querySelector('.tooltip-text');
 
   let left = event.clientX - child.offsetWidth / 2;


### PR DESCRIPTION
# 現象

　特定のパターンに合致するとき、ツールチップが設定されているテキストにマウスオーバーしたときにエラー（ null 参照）が発生する。

# 再現方法

1. ツールチップが設定されるテキスト内に任意の HTML 要素がつくられるようなメッセージを記述し、送信する
2. 当該 HTML 要素部分にマウスオーバーする

　具体的には次のようなメッセージで再現できる。

```<tip>this is a <b>keyword</b>=>description</tip>```

※この例の場合、 `<b>keyword</b>` 部分が _b_ 要素となり、その部分にマウスオーバーすると再現する

# 原因

　`obj` （ = `event.target` ）が内側の要素（前述の例であれば _b_ 要素）であり、その内部には `.tooltip-text` が存在しないため。
　（ `child` が null となり、 `child.offsetWidth` が null 参照となる）

# 解決方法

　`obj` が `.tooltip-text` を内包する要素（具体的には `.tooltip` の要素）となるようにする。