### PR TITLE
共有メモに関する２つの不具合を修正

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -333,7 +333,7 @@ html,body {
 .memo ul#memo-list li {
   position: relative;
 }
-.memo ul#memo-list li:empty {
+.memo ul#memo-list li.removed {
   display: none !important;
 }
 .memo ul#memo-list li[onclick]:hover {

--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -740,7 +740,7 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   opacity: 0.3;
 }
 /* 共有メモ */
-#memo-list:empty::before {
+#memo-list:not(:has(li:not(.removed)))::before {
   content: '共有メモ';
   opacity: 0.3;
 }

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1169,7 +1169,7 @@ function memoUpdate(){
     shareMemo[i] ||= '';
     let newMemo = document.createElement('li');
     newMemo.innerHTML = tagConvert( (shareMemo[i].split(/\n/))[0] ).replace(/<.+?>/g,'');
-    if (newMemo.innerHTML === '') {
+    if (newMemo.innerHTML === '' && shareMemo[i].trim() === '') {
       newMemo.classList.add('removed');
     }
     newMemo.setAttribute("onclick","memoSelect("+i+");");

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1169,6 +1169,9 @@ function memoUpdate(){
     shareMemo[i] ||= '';
     let newMemo = document.createElement('li');
     newMemo.innerHTML = tagConvert( (shareMemo[i].split(/\n/))[0] ).replace(/<.+?>/g,'');
+    if (newMemo.innerHTML === '') {
+      newMemo.classList.add('removed');
+    }
     newMemo.setAttribute("onclick","memoSelect("+i+");");
     newMemo.dataset.num = Number(i)+1;
     document.getElementById("memo-list").appendChild(newMemo);


### PR DESCRIPTION
※両者の修正内容が密接に関わっているので単一の PR にまとめてあります

# 不具合１

## 現象

すべての共有メモを削除しても、初期状態と同様の表示にもどらない。
具体的には、共有メモリストにおける「共有メモ」という文言が表示されない。

## 再現手順

1. 適当なルームを用意する
2. 共有メモを追加する
3. 追加した共有メモをすべて削除する

![ytchat-memo-bug-1](https://github.com/yutorize/ytchat-adv/assets/44130782/c5835c41-a876-49a2-9669-3340117d97eb)

## 原因

`共有メモ` の文言の表示は、「リスト内部が空であること」を条件としていた。（ `:empty` ）
しかしながら、共有メモを削除しても、リスト内に要素が残る（非表示になるにすぎない）実装になっている。

## 修正方法

8066953a60124ac8cfb769658a24648f7c2cd72e

削除されたメモを class で明示するようにする。（ `.removed` ）
そのうえで、 `共有メモ` の文言の表示の条件を、「削除されていない要素を含まないこと」に変更。（ `:not(:has(li:not(.removed)))` ）

# 不具合２

## 現象

先頭が空行の共有メモを正しく追加できない。
具体的には、追加してもリストに表示されない。

## 再現手順

1. 適当なルームを用意する
2. 先頭が空行である共有メモを追加する

![ytchat-memo-bug-2](https://github.com/yutorize/ytchat-adv/assets/44130782/10351a81-75bd-47d1-95c6-884d7989a604)

## 原因

見出しが空になる場合、削除されたメモとみなされていた。
（そして、削除されたあつかいのメモは非表示となる）

## 修正方法

0579ac6e7743b97537d8f639889178956b130c85

削除されたメモを非表示にするためのスタイルの条件づけを、要素が空であること（ `:empty` ）から、明示的に削除を示す class があること（ `.removed` ）に変更。