### PR TITLE
Fix: ヘルプに記述されている“ヘカトンケイレスの武器乱舞”の式が適切でないのを修正

### DIFF
--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -165,7 +165,7 @@
     </p>
     <p>
       例4：「すべての［部位：腕］が健在なヘカトンケイレスの《武器乱舞》のダメージ」<br>
-      　<span style="color:#ee7777;">2</span><b>D</b><span style="color:#eebb77;">6</span><span style="color:#77ee77;">**6+5</span><br>
+      　<span style="color:#ee7777;">2</span><b>D</b><span style="color:#eebb77;">6</span><span style="color:#77ee77;">*6+5</span><br>
     </p>
     <p>
       例5：「超越判定」<br>


### PR DESCRIPTION
* before: `2D6**6+5`
* after: `2D6*6+5`

`**` は冪乗を意味する記法だが、この例においては乗算が正しい。（『モンストラスロア』95頁または『バルバロステイルズ』59頁）
（まあそれはそれとして修正前の記述でも乗算相当で動作するのだが、それは別の話）