### PR TITLE
ユニットのステータス項目をコマンドから参照できるように

### DIFF
--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -154,6 +154,9 @@
     color: #99ccee;
     font-style: normal;
   }
+  .chat-palette i.unit-status {
+    filter: hue-rotate(-120deg);
+  }
   .chat-palette em {
     color: #cc99ee;
     font-style: normal;

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1562,6 +1562,23 @@ function formSubmit(objId,unitName){
   else {
     comm = paletteCheck(selectedSheet, comm);
   }
+
+  if (comm.includes('{') && unitList[unitName] != null) {
+    /** @var {RegExpMatchArray|null} */
+    let m;
+    while (m = comm.match(/\{(.+?)}/)) {
+      const statusName = m[1];
+      if (unitList[unitName]['sttnames'].includes(statusName)) {
+        const statusValue = unitList[unitName]['status'][statusName];
+        const [currentValue,] = statusValue.split('/');
+        comm = comm.replace(m[0], currentValue);
+      } else {
+        console.warn(`Missing status: ${statusName}`);
+        break; // ほっとくと無限ループになるので、解決できないステータス名があったらその時点で打ち切る.
+      }
+    }
+  }
+
   // 発言先タブチェック
   let target = 0;
   if(obj.closest('[data-tab]')){ target = obj.closest('[data-tab]').dataset.tab; }

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1109,6 +1109,7 @@ function paletteSet(id,textData){ // テキストからセレクトボックス�
   }
 }
 function paletteLineParamReplace(id,text){
+  const unitStatusNames = unitList[unitIdToName[id]]?.sttnames.map(x => x.toLowerCase()) ?? [];
   if(text === '') { return ['　'] }
   text = htmlEscape(text);
   if(text.match(/^\/\/(.*?)[=＝](.*)$/)){ return [`<b>${RegExp.$1}</b><div><input data-label="${RegExp.$1}" value="${RegExp.$2}" onchange="paletteLineParamChange('${id}',this)"></div>`, 'param']; }
@@ -1117,6 +1118,7 @@ function paletteLineParamReplace(id,text){
       const varName = toHalfWidth(varNameRaw).toLowerCase();
       if     (varName in diceParams)       { return `<em>${raw}</em>` }
       else if(varName in paletteParams[id]){ return `<i>${raw}</i>` }
+      else if(unitStatusNames.includes(varName)){ return `<i class="unit-status">${raw}</i>` }
       else { return raw };
     })]
   }


### PR DESCRIPTION
# 内容

コマンド（メッセージ）からユニットのステータスを参照する機能を追加。

# 目的

「ＨＰ」や「行動値」など、ユニットのステータスとして管理される値を参照するルールやデータをあつかうときに、機械的に解決できる（＆チャットパレット変数との二重管理にならない）ようにしたい。

該当するゲーム処理は、たとえば『ＤＸ３』の《雷鳴の申し子》（『エフェクトアーカイブ』P42）や《スピードスター》（『リンケージマインド』P81）など。

# 使い方

チャットパレット変数と同様の記法（ `{ステータス名}` ）で参照できる。

例： `2d6+{HP}`