### PR TITLE
ダイスロールの繰り返し回数の上限を 20 に変更

### DIFF
--- a/lib/pl/dice.pl
+++ b/lib/pl/dice.pl
@@ -96,7 +96,7 @@ sub diceRoll {
     if($target eq ''){ return ''; }
   }
   
-  $repeat = ($repeat > 10) ? 10 : (!$repeat) ? 1 : $repeat;
+  $repeat = ($repeat > 20) ? 20 : (!$repeat) ? 1 : $repeat;
   my @result;
   foreach my $i (1 .. $repeat){
     push(@result,

--- a/lib/pl/dice/sw2.pl
+++ b/lib/pl/dice/sw2.pl
@@ -63,7 +63,7 @@ sub rateRoll {
   if($rate > 100){ $rate = 100; } elsif($rate < 0){ $rate = 0; }
   if($crit <= 0){ $crit = 0; } elsif($crit < 3){ $crit = 3; }
   
-  $repeat = ($repeat > 10) ? 10 : (!$repeat) ? 1 : $repeat;
+  $repeat = ($repeat > 20) ? 20 : (!$repeat) ? 1 : $repeat;
   my @result;
   foreach my $i (1 .. $repeat){
     push(@result,


### PR DESCRIPTION
SW2 の広範囲の効果の一般的な範疇での最大対象数の最大値が 20 体なので、 20 回はまとめてロールしたいことがある