### PR TITLE
Fix: ユニットのステータス名に括弧が含まれる場合に正常に表示・更新されない不具合を修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -574,7 +574,7 @@ function logGet(){
         // TOPIC更新
         else if(value['system'] === 'topic') { topicChange(value['info']); }
         // ユニット更新
-        else if (value['system'].match(/^unit:\((.*?)\)/)){
+        else if (value['system'].match(/^unit:\((.*?)\)$/)){
           const stts = RegExp.$1.split(' \| ');
           if (!unitList[value['name']]){
             unitList[value['name']] = { 'color': value['color'], 'status': {}, 'sttnames': [] };


### PR DESCRIPTION
# 現象

ユニットのステータス名に括弧（厳密には閉じ括弧 `')'` ）が含まれる場合に正常に反映されない不具合を修正

# 再現方法

ステータス名に括弧が含まれるユニットを追加する

## 再現データの例

```
サンプルキャラクター@new
HP:20/20
MP:15/15
移動速度(通常):30
移動速度(飛行):60
防御力:5
```

## 再現イメージ

![ytchat-unit-bug](https://github.com/yutorize/ytchat-adv/assets/44130782/2bac6943-a283-41ef-8752-b3c28750d462)

※「HP」「MP」以外のステータスが表示されていない

# 原因

クライアント（ JS ）側でメッセージをパースする際に、 `)` があった時点で打ち切られていた。