### PR TITLE
SW2.x の威力表ロールで存在しないオプションが指定されていた場合を弾く

### DIFF
--- a/lib/pl/dice/sw2.pl
+++ b/lib/pl/dice/sw2.pl
@@ -97,6 +97,8 @@ sub rateCalc {
   my $repeat   = shift;
   my $unique   = (exists $unique{$rate}) ? $unique{$rate}{'name'} : '';
   
+  return '' if $form =~ /[a-z]/i;
+  
   my $total = 0;
   my $code = $unique || "威力${rate}";
   my @results;


### PR DESCRIPTION
# 内容

従来は未定義のオプションが指定されていてもそれを無視するかたちで動作していた。
これを、未定義のオプションらしきものがある場合にはコマンドとして解決しないように変更する。

## 従来の挙動の例

![ytchat-sw2-damage-roll-with-unsupported-option](https://github.com/yutorize/ytchat-adv/assets/44130782/cdfd3c4f-e930-4b26-9b5e-7a9e1b1dcf73)

# 目的

コマンドとして動作してしまうと、そこに未定義のオプション（らしきもの）が含まれていたことがわかりづらい。
（厳密には、ログに表示されるコマンドにアルファベットが残っていたらそれは未定義のオプションらしきものがあったということになるのだが、これは明文化されていない仕様でありかつ出力フォーマットを把握していなければ認識できず、また直感的ではない）

指定したつもりのオプションが意図どおりに適用されないまま、（あたかも正常であるかのように）ダイスロールが解決されてしまうと、意図と異なった結果によってゲームが進行しかねないという問題がある。

未定義のオプション（らしきもの）が指定されてしまうケースには、

* 単純な typo
* 誤って他のダイスボットの記法で記述してしまう

などがある。
後者の具体例として、頻発しやすいものに BCDice の半減オプション（ `h` を指定する）などがある。