### PR TITLE
ユニットの行動済みマークを Material Symbols のものに統一する

### DIFF
--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -141,6 +141,14 @@ input.toggle-button:not(:checked) + label::after {
   background-color: #777;
 }
 
+/* ユニットのチェックマーク */
+i.unit-check-mark::before,
+.contains-unit-check-mark::before {
+  content: "\e5ca";
+  font-family: "Material Symbols Outlined";
+  font-variation-settings: 'FILL' 1;
+}
+
 /* フォント */
 html,
 body,

--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -561,17 +561,23 @@ body.rom .sheet { display: none; }
 .sheet-body .status-remocon-area ul.status-remocon-others li {
   margin-top: .4rem;
 }
-.sheet-body .status-remocon-area ul li.dice-button.checks button::before {
-  content: '✔';
+.sheet-body .status-remocon-area ul li.checks {
+  grid-column: span 6;
+}
+.sheet-body .status-remocon-area ul li.checks button {
+  display: flex;
+  align-items: center;
+}
+.sheet-body .status-remocon-area ul li.checks button::before {
   opacity: 0.3;
 }
-.sheet-body .status-remocon-area ul li.dice-button.checks button:hover::before {
+.sheet-body .status-remocon-area ul li.checks button:hover::before {
   opacity: 1;
 }
-.sheet-body .status-remocon-area ul li.dice-button.checks.checked button::before {
+.sheet-body .status-remocon-area ul li.checks.checked button::before {
   opacity: 1;
 }
-.sheet-body .status-remocon-area ul li.dice-button.checks.checked button:hover::before {
+.sheet-body .status-remocon-area ul li.checks.checked button:hover::before {
   opacity: 0.3;
 }
 .sheet-body .status-remocon-area ul.status-remocon-others li.dice-button.delete {

--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -508,9 +508,11 @@ body {
   width: max-content;
   border-top: 0;
   border-radius: 0 0 .8rem .8rem;
+  display: inline-flex;
+  align-items: center;
 }
 .check-buttons button::before {
-  content: '✔';
+  font-size: 0.88rem;
   opacity: 0.3;
 }
 .check-buttons button:hover::before {

--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -428,6 +428,9 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   font-style: normal;
   opacity: 0.85;
 }
+.logs dl dd.info.dice i.unit-check-mark {
+  margin-left: 0;
+}
 .logs dl dd.info.dice b,
 .logs dl dd.info.dice strong {
   color: #f33;

--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -105,14 +105,14 @@
     <tr><th>@new ステータス名:文字列  </th><td>ユニット、ステータスを新規に設定します。<br>既に同名のものがある場合は上書きされます。<br>例外的に、名前欄・ユニット欄に存在しない名前でも指定できます。<br>例: <code>大蜥蜴@new 頭部HP:30/30 胴体HP:40/40</code>、<code>ゴブリンの群れ@new ＡHP:16/16 ＢHP:16/16 ＣHP:16/16 防護:2</code></td></tr>
     <tr><th>@add ステータス名:文字列  </th><td>ステータスを追加で設定します。<br>既に同名のものがある場合は上書きされます。<br>例: <code>@add 使い魔MP:7/7</code>、</td></tr>
     <tr><th>@delete     </th><td>発言者と同名のユニットを削除する。</td></tr>
-    <tr><th>@check          </th><td>ユニット一覧の自分の名前にチェック（✔）を入れる。<br>例: <code>@check 行動終了</code></td></tr>
-    <tr><th>@uncheck         </th><td>ユニット一覧の自分の名前のチェック（✔）を外す。<br>例: <code>@uncheck まだやることあった</code></td></tr>
+    <tr><th>@check          </th><td>ユニット一覧の自分の名前にチェック（<i class="unit-check-mark"></i>）を入れる。<br>例: <code>@check 行動終了</code></td></tr>
+    <tr><th>@uncheck         </th><td>ユニット一覧の自分の名前のチェック（<i class="unit-check-mark"></i>）を外す。<br>例: <code>@uncheck まだやることあった</code></td></tr>
     <tr><th>/ready       </th><td rowspan="2">「レディチェック（準備確認）」をおこなう。<br>メッセージを指定した場合、その文面とともにレディチェックをおこなう。<br>例： <code>/ready 割り込み行動のないひとはチェックしてください</code></td></tr>
     <tr><th>/ready メッセージ</th></tr>
-    <tr><th>/round+数値  </th><td>ラウンド数を「数値」進める。<br>ユニットの✔は全て外れる。</td></tr>
-    <tr><th>/round-数値  </th><td>ラウンド数を「数値」戻す。<br>ユニットの✔は全て外れる。</td></tr>
-    <tr><th>/round=数値  </th><td>ラウンド数を「数値」にする。<br>ユニットの✔は全て外れる。</td></tr>
-    <tr><th>/roundreset  </th><td>ラウンド数を「0」にする。<br>ユニットの✔は全て外れる。</td></tr>
+    <tr><th>/round+数値  </th><td>ラウンド数を「数値」進める。<br>ユニットの<i class="unit-check-mark"></i>は全て外れる。</td></tr>
+    <tr><th>/round-数値  </th><td>ラウンド数を「数値」戻す。<br>ユニットの<i class="unit-check-mark"></i>は全て外れる。</td></tr>
+    <tr><th>/round=数値  </th><td>ラウンド数を「数値」にする。<br>ユニットの<i class="unit-check-mark"></i>は全て外れる。</td></tr>
+    <tr><th>/roundreset  </th><td>ラウンド数を「0」にする。<br>ユニットの<i class="unit-check-mark"></i>は全て外れる。</td></tr>
     <tr><th>/topic 文字列</th><td>トピックの内容を「文字列」で更新する。</td></tr>
     <tr><th>/memo 文字列 </th><td>「文字列」の内容のメモを追加する。</td></tr>
     <tr><th>/bg 文字列 URL</th><td rowspan="2">「URL」の画像を背景に設定する。<br>「文字列」がタイトルに設定される。<br>「mode=tiling」を指定すると、タイリングして表示される。<br>「/bg」以降の内容は順番は問わない。<br>（<code>/bg URL タイトル mode=tiling</code>などでもよい）</td></tr>

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -123,7 +123,7 @@
           </div>
           
           <div class="check-buttons">
-            <button onclick="unitCheckSubmit()"><span class="small">行動済</span></button>
+            <button onclick="unitCheckSubmit()" class="contains-unit-check-mark"><span class="small">行動済</span></button>
           </div>
           <div class="form-dice" id="form-dice-0">
             <span class="del edit button" onclick="diceDel(0);" title="ダイス欄を削除">－</span>

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -734,6 +734,12 @@ function logGet(){
             else if(value['userId'] == userId){ memoSelect(num); }
           }
         }
+        // ユニットの行動済みチェック更新
+        else if (value['system'].match(/^check:[01]/)) {
+          if (value['info'] != null) {
+            value['info'] = value['info'].replace('✔', '<i class="unit-check-mark"></i>');
+          }
+        }
         // 画像
         else if(value['system'] === 'image') {
           const url = value['info'];
@@ -1382,11 +1388,11 @@ function statusUpdate () {
     document.getElementById('stt-url-'+id ).innerHTML = (unitList[name]['url']  == null)?'': `<a href="${unitList[name]['url']}" target="_blank"></a>`;
     if(Number(unitList[name]['check'])){
       document.getElementById('stt-unit-'+id).classList.add('check');
-      document.querySelector(`#sheet-unit-${id} .dice-button.checks`).classList.add('checked');
+      document.querySelector(`#sheet-unit-${id} .checks`).classList.add('checked');
     }
     else {
       document.getElementById('stt-unit-'+id).classList.remove('check');
-      document.querySelector(`#sheet-unit-${id} .dice-button.checks`).classList.remove('checked');
+      document.querySelector(`#sheet-unit-${id} .checks`).classList.remove('checked');
     }
     // 指定個数以上なら2キャラ分使う
     if(viewCount > 5){

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -931,8 +931,8 @@ r18+{追加D} ダメージ！
               <textarea class="form-comm" name="stt-memo" id="edit-stt-${unitId}-memo-value" data-comm-pre="@memo" data-palette-target='${unitNameEscaped}' rows="1" placeholder="メモ">${unitList[unitName]['memo'].replace(/<br>/g,"\n")}</textarea>
               <button onclick="formSubmit('edit-stt-${unitId}-memo-value','${unitNameEscaped}');"></button>
             </li>
-            <li class="dice-button checks">
-              <button onclick="unitCheckSubmit('${unitId}');">行動済</button>
+            <li class="checks">
+              <button onclick="unitCheckSubmit('${unitId}');" class="contains-unit-check-mark">行動済</button>
             </li>
             <li class="dice-button delete"><button onclick="unitCommandSubmit('delete' ,'${unitId}');">削除</button></li>
           </ul>


### PR DESCRIPTION
ユニットの行動済みを意味するチェックマークの表現を統一する。

ステータス一覧上では Material Symbols の **Check** だったが、他の箇所（それを操作するボタン内・ヘルプ内・ログ）では `✔` ( U+2714, HEAVY CHECK MARK ) だった。
前者に統一した。
