### PR TITLE
『ソード・ワールド』の威力表コマンドのヘルプに、クリティカル値を省略した場合の挙動を明記する

### DIFF
--- a/lib/html/help.html
+++ b/lib/html/help.html
@@ -218,7 +218,7 @@
       <b>R</b><span style="color:#ee7777;">威力</span><span style="color:#eebb77;">[C値]</span><span style="color:#77ee77;">+修正値</span><span style="color:#ee77bb;">!必殺</span><span style="color:#bb77ee;">$出目</span><span style="color:#77aaee;">k首切</span><span style="color:#cc77ee;">:繰返し回数</span>
     </p>
     <p>
-      <span style="color:#77ee77;">+修正値</span>・<span style="color:#eebb77;">@C値</span>・<span style="color:#ee77bb;">!必殺</span>・<span style="color:#bb77ee;">$出目</span>・<span style="color:#77aaee;">k首切り</span>・<span style="color:#cc77ee;">:繰返し回数</span>は省略できます。<br>
+      <span style="color:#77ee77;">+修正値</span>・<span style="color:#eebb77;">@C値</span>・<span style="color:#ee77bb;">!必殺</span>・<span style="color:#bb77ee;">$出目</span>・<span style="color:#77aaee;">k首切り</span>・<span style="color:#cc77ee;">:繰返し回数</span>は省略できます。C値を省略した場合、「C値：なし」のように振る舞います。<br>
       　修正値の末尾に「<span style="color:#77ee77;">//</span>」をつけると半減した結果になります。半減した上でさらに修正がある場合、「<span style="color:#77ee77;">//</span>」の後ろにさらに付け足します（「<span style="color:#77ee77;">//+1</span>」など）。<br>
       　!必殺、k首切は、効果による出目ないし威力の上昇値を記入します。<br>
       　$出目は、特定効果による出目の固定値や修正値（クリティカルレイ等）を記入します。<br>


### PR DESCRIPTION
威力表コマンドでクリティカル値が明示されたなかった場合の挙動について、「 `C値を省略した場合、「C値：なし」のように振る舞います。` 」と明記した。

省略した場合には“なし”のように振る舞うのは自明のように思われるかもしれないが、（こまったことに） BCDice のソード・ワールド系列のインタフェースにおいてはクリティカル値が省略されたときはクリティカル値を 10 とみなすようになっており、 BCDice ユーザーが一定程度存在する現況においては自明とも言い切れないため。