### PR TITLE
Fix: コンフィグ内の文字列置換定義で置換前の文字列があらわす正規表現内の文字クラスに、 Unicode 16 進において 4 桁以内に収まらない文字が含まれていた場合に、ルーム内で正しく置換されない不具合を修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -985,7 +985,7 @@ function tagConvert (comm){
   });
   replaceRegex.forEach(item => {
     for (const [key, value] of Object.entries(item)) {
-      comm = comm.replace(new RegExp(key,'g'), value);
+      comm = comm.replace(new RegExp(key,'gu'), value);
     }
   });
   


### PR DESCRIPTION
タイトルがなにを言っているのかわからないと思うので、とりあえず以下の「表面的な現象」を見てください。
（端的にいうとサロゲートペア関連の問題です）

# 現象

## 表面的な現象

特定のパターンでテキスト置換がはたらいていなかった。

たとえば、デフォルトで含まれている置換定義の `{ '\[([□☑🗨]|宣言?)\]' => '<i class="s-icon active"><i>[宣]</i></i>' }` があっても、 `[🗨]全力攻撃` というメッセージが次の画像のように表示される。

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/205a94ac-e83d-4833-aa47-a7eeaaa01705)

## 内部的な現象

置換前文字列は実質的には正規表現であり、その内部に文字クラスがもちいられ、文字クラス内にサロゲートペアを要する文字が含まれている場合に、意図どおりにマッチしない。

（上掲の例だと、文字クラスは `[□☑🗨]` の部分で、サロゲートペアを要する文字は `🗨` である）

# 原因

JS の正規表現の文字クラスは、 Unicode 非対応モードにおいては、サロゲートペアが１文字にマッチしない。

https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Regular_expressions/Character_class
> [Unicode 非対応モード](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_%E5%AF%BE%E5%BF%9C%E3%83%A2%E3%83%BC%E3%83%89)では、正規表現は [BMP](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_%E6%96%87%E5%AD%97%E3%80%81unicode_%E3%82%B3%E3%83%BC%E3%83%89%E3%83%9D%E3%82%A4%E3%83%B3%E3%83%88%E3%80%81%E6%9B%B8%E8%A8%98%E7%B4%A0%E3%82%AF%E3%83%A9%E3%82%B9%E3%82%BF%E3%83%BC) 文字の並びとして解釈されます。したがって、文字クラスのサロゲートペアは 1 文字ではなく 2 文字を表します。

# 解決方法

_RegExp_ オブジェクトの作成時に `'u'` オプションを指定し、 Unicode 対応モードを有効にする。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode_%E5%AF%BE%E5%BF%9C%E3%83%A2%E3%83%BC%E3%83%89