### PR TITLE
チャットパレットについてあるていどの表示領域を確保する

### DIFF
--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -817,6 +817,29 @@ body {
 }
 .sheet {
 }
+.sheet:has(.chat-palette-area) {
+  display: grid;
+  grid-template-rows: max-content 1fr;
+  grid-template-columns: 1fr;
+
+  .sheet-body {
+    grid-template-rows: max-content 1fr max-content;
+
+    .status-remocon-area {
+      display: grid;
+      grid-template-rows: max-content max-content 1fr max-content;
+      grid-template-columns: 1fr;
+      height: auto;
+      max-height: max(calc(100vh - 44rem), 18rem);
+
+      .status-remocon-list {
+        max-height: 100%;
+        overflow-y: auto;
+        grid-auto-rows: max-content;
+      }
+    }
+  }
+}
 @keyframes sheetrightfade {
   from { opacity: 0.5; left: 16em; right: -16em; }
   to   { }


### PR DESCRIPTION
# 背景

ウィンドウの高さが小ささの環境などで、（ SW2 の複数の部位をもつキャラクターなどの）ステータス項目が多いユニットの場合、チャットパレットの表示領域が、ステータスリモコンによって圧迫されてほとんどまともに操作できなくなる。

（例）
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/80632b81-5595-4090-a100-397f0c6cba04)

# 変更内容

上記の問題を緩和するために、ステータスリモコンが専有する高さをあるていど限定する。（ `max-height: max(calc(100vh - 44rem), 18rem);` ）

ステータスリモコンの内容が高さに対して大きい場合、ステータスのリスト（ `.status-remocon-list` ）をスクロールさせることで対応する。

（これでもウィンドウが極端に小さいときはどうしようもないが、あるていどの小ささまではマシになるはず）