### PR TITLE
発言編集をウィンドウを開いた時、その編集欄（ textarea ）をフォーカスする

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -442,6 +442,7 @@ function rewriteOpen(num){
     .replace(/&gt;/g, '>')
   obj.value = setValue;
   autosizeUpdate(obj);
+  obj.focus();
 }
 function rewriteNameOpen(num,name){
   boxOpen('rewrite-name-form');


### PR DESCRIPTION
* 発言を編集するに際しては、まず編集欄にフォーカスするところから操作を始める蓋然性がそれなりに高いはず。
* 仮にそうでない（フォーカスから始めない）場合であっても、直前にしている操作は編集ボタンのクリックのはずであり、それまでのフォーカスの維持を考慮する必要はまったくない。