### PR TITLE
ゲームごとのツールチップを設定できるように

### DIFF
--- a/lib/pl/room.pl
+++ b/lib/pl/room.pl
@@ -192,6 +192,16 @@ $ROOM->param(userRoomFlag => exists($set::rooms{$id}) ? 0 : 1);
 $ROOM->param(replaceRule => decode('utf-8', encode_json \%set::replace_rule ) );
 $ROOM->param(replaceRegex => decode('utf-8', encode_json \@set::replace_regex ) );
 
+my @gameTooltips = $games{$game}{tooltips} ? @{$games{$game}{tooltips}} : ();
+if ($#gameTooltips >= 0) {
+  foreach (@gameTooltips) {
+    my %h = %{$_};
+    for my $k (keys %h) {
+      my $v = $h{$k};
+      $set::tooltips{$k} = $v;
+    }
+  }
+}
 $ROOM->param(tooltips => decode('utf-8', encode_json \%set::tooltips) );
 
 $ROOM->param(base64Mode => $set::base64mode );


### PR DESCRIPTION
https://github.com/yutorize/ytchat-adv/commit/91c97b9adeaaabaf26bb4e632fc81c9c4de70d05 でツールチップ機能が追加されたものの、その設定はゆとチャ全体に対してしかおこなえない仕様になっていた。

ツールチップ機能をゲームタームなどに利用することを考えると、この仕様では不十分であり、ゲームごとの設定ができなければ需要を満たしづらい。具体的な理由は以下：

* タームが一般的に出現しうる文字列である場合、そのタームのないゲームにおいてもツールチップ化されてしまう。（「転倒」などの一般名詞をそのままターム化したものなどが典型的である）
* 複数のゲームが同じ文字列をタームとして定義しているとき、ゲームごとの差異を現状のツールチップ設定では表現できない。（たとえば、「全力移動」というタームは、『SW2』にも『DX3』にも存在する）

以上のことから、ゲームごとのツールチップを設定できるようにする。

たとえば、次のように __lib/pl/config-default.pl__ に記述しておくことで、『DX3』においてのみ有効なツールチップを定義できる。

```
  'dx3' => {
    'name' => 'ダブルクロス3rd',
    'status' => ['HP','侵蝕','ロイス','財産','行動'],
    'bcdice' => 'DoubleCross',
    'faces' => 10,
    'tooltips' => [
        {'重圧' => '「タイミング：オートアクション」のエフェクト使用不可。マイナーアクションまたはメジャーアクションで解除できる。'},
        {'硬直' => '戦闘移動・全力移動不可。マイナーアクションまたはメジャーアクションで解除できる。'},
        {'邪毒' => 'クリンナッププロセスに［ランク×３］点のＨＰダメージを受ける。'},
        {'放心' => '判定のダイスが－２個される。クリンナッププロセスで解除される。'},
        {'暴走' => 'リアクションとカバーリング不可。マイナーアクションまたはメジャーアクションで解除できる。'},
        {'憎悪' => '憎悪の対象に攻撃をおこなわなければならない。一度攻撃をおこなうと解除される。'},
    ],
  },
```

なお、ゲームごとのツールチップ定義とゆとチャ全体のツールチップ定義が競合する場合、前者を優先する。
（全体に設定するような普遍的な語句よりは、ゲーム固有の語句を優先するほうが、より便宜にかなうであろうとの考え）