### PR TITLE
サブ発言欄のアイコンを上下中段揃えにする

### DIFF
--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -588,18 +588,14 @@ body {
 }
 .form-dice .dice-button i {
   position: relative;
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 2.4em;
   border-width: 0 .1rem 0 0;
   border-radius: .5em 0 0 .5em;
 }
 .form-dice .dice-button i::before {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: .4rem;
-  margin: auto;
-  text-align: center;
   font-size: 1.4rem;
   line-height: 1;
   font-family: "Material Symbols Outlined";


### PR DESCRIPTION
２行以上にわたる内容を入力して縦幅が大きくなったときに、従来は下揃えのように見えていた。

これを上下中央（中段）揃えのようにする。

**before**
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/bc5e955d-ac44-403d-8930-71b02f340ec5)

**after**
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/f084c62b-b62e-4248-9505-328b2bd8704c)
