### PR TITLE
タブ切り替えボタンを追加

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -1328,6 +1328,58 @@ body.rom .input-form { display: none !important; }
   display: block;
 }
 
+.tab-group {
+  &.main > .switch-area {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: auto;
+    height: calc((1em * (0.92 * (1 + (0.3 * 2)))) + 1px + 0.2rem); /* タブリストの大きさに合わせる */
+    display: flex;
+    flex-flow: row;
+    align-items: center;
+    padding: 1px 0.25rem 1px 0;
+
+    > button {
+      height: max-content;
+      max-height: 100%;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0;
+      background: none;
+      border: none;
+      color: #7895;
+
+      &:hover {
+        color: #789;
+        box-shadow: none;
+      }
+
+      &:first-child {
+        margin-right: 0.25em;
+      }
+
+      &::before {
+        font-family: "Material Symbols Outlined";
+        font-variation-settings: 'FILL' 1;
+      }
+
+      &[data-direction="previous"]::before {
+        content: "\e408";
+      }
+
+      &[data-direction="next"]::before {
+        content: "\e409";
+      }
+    }
+  }
+
+  &:not(.main) > .switch-area {
+    display: none;
+  }
+}
+
 #tab-add-area {
   position: absolute;
   top: 2em;

--- a/lib/css/chat-layout-sp.css
+++ b/lib/css/chat-layout-sp.css
@@ -281,6 +281,10 @@ input[type=range]::-moz-range-thumb {
   height: 100%;
   flex-direction: column-reverse;
   overflow: hidden;
+
+  > .switch-area {
+    display: none;
+  }
 }
 #chat-area[data-layout-tab-bar="top"] .tab-group {
   flex-direction: column;

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1460,6 +1460,22 @@ function tabToggle(num){
   const chatTab = document.getElementById('chat-tab'+num);
   chatTab.classList.toggle('close');
 }
+function moveTabPrevious() {
+  if (mainTab) {
+    const num = (mainTab > 1) ? mainTab - 1 : Object.keys(tabList).length;
+    mainTabChange(num);
+  } else {
+    mainTabChange(1);
+  }
+}
+function moveTabNext() {
+  if (mainTab) {
+    const num = (mainTab < Object.keys(tabList).length) ? mainTab + 1 : 1;
+    mainTabChange(num);
+  } else {
+    mainTabChange(1);
+  }
+}
 
 // ルーム設定のselectにセット
 function tabOptionSet(){
@@ -1991,20 +2007,12 @@ document.onkeydown = function(e){
     // タブ←
     else if (e.key === 'ArrowLeft') {
       e.preventDefault();
-      if(mainTab){
-        const num = (mainTab > 1) ? mainTab-1 : Object.keys(tabList).length;
-        mainTabChange(num);
-      }
-      else { mainTabChange(1); }
+      moveTabPrevious();
     }
     // タブ→
     else if (e.key === 'ArrowRight') {
       e.preventDefault();
-      if(mainTab){
-        const num = (mainTab < Object.keys(tabList).length) ? mainTab+1 : 1;
-        mainTabChange(num);
-      }
-      else { mainTabChange(1); }
+      moveTabNext();
     }
   }
   // フォーム上のキー動作

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1297,6 +1297,29 @@ function tabGroupAdd(groupNum){
     });
   }
 
+  {
+    const switchArea = document.createElement('div');
+    switchArea.classList.add('switch-area');
+
+    for (const direction of ['previous', 'next']) {
+      const button = document.createElement('button');
+      button.dataset.direction = direction;
+
+      switch (direction) {
+        case 'previous':
+          button.addEventListener('click', () => moveTabPrevious());
+          break;
+        case 'next':
+          button.addEventListener('click', () => moveTabNext());
+          break;
+      }
+
+      switchArea.appendChild(button);
+    }
+
+    newGroup.appendChild(switchArea);
+  }
+
   tabQuantityCheck();
   
   return newGroup;


### PR DESCRIPTION
# 変更内容

タブを切り替えるためのボタンを追加する。

# 目的

現バージョンでは、メインのタブグループを変更するには、キーボードショートカット（ _Ctrl+←_, _Ctrl+→_ ）をもちいる他になかった。
（バージョン 0.x 系ではＧＵＩがあったが、 1.00 か 1.01 あたりでタブの仕様が大幅に変更されたときになくなった）

これでは不便なので、ポインティングデバイスの操作で切り替えられるようにする。
（ゆとチャは、基本的には、ポインティングデバイスの存在を想定したツールだと認識しています）

あと…… Ctrl+アローキーが……押しづらい……。

# 仕様

メインタブグループのタブリストの右端に、切り替え用のボタンを追加。

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/7f83a20f-bfeb-4861-b0e4-9ca840688f77)
（そこまで頻繁にさわるＵＩではないはずなので、存在感をできるかぎり薄くしています）

* 左側のボタンをクリックすると、 _Ctrl+←_ と同等の動作をする
* 右側のボタンをクリックすると、 _Ctrl+→_ と同等の動作をする