### PR TITLE
ゲームが SW2 のとき、デフォルトでサブ発言欄に「成長ダイス」のコマンドを設定する

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -73,6 +73,8 @@ if(!roomConfig.diceForms){
       {'type':'dice','value':''},
       {'type':'dice','value':''},
     ]
+  } else if (gameSystem === 'sw2') {
+    roomConfig.diceForms[1][2] = {type: 'dice', value: '成長ダイス'};
   }
 }
 let nameList   = roomConfig.name;


### PR DESCRIPTION
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/d1680bf5-e658-4474-b020-9606b091a197)

# 理由

* SW2 のセッションにおいて、能力値の成長は、原則として１セッションに１回はおこなう
* それでいて１セッションに１回しかおこなわないので、コマンドが何だったのかいまいち覚えられない