### PR TITLE
ゲームが SW2 のとき、目標値つきの 2d6 ロールの出目が 1,1 だったら自動失敗とする

### DIFF
--- a/lib/pl/dice.pl
+++ b/lib/pl/dice.pl
@@ -132,6 +132,16 @@ sub diceCalc {
     $base =~ s/<dice>/ $num\[$text\] /;
   }
   $base =~ s/[\.\+\-\*\/\s]+$//gi; # 末尾の演算子は消す
+
+  if (
+      ($::in{'game'} eq 'sw2') &&
+      $#code == 0 &&
+      $code[0] =~ /^2D6$/i &&
+      $rel =~ /^>=?$/ &&
+      $dice_value == 2
+  ) {
+    return $code[0] . $rel . $targets . ' → 2[1,1...] → 自動失敗';
+  }
   
   ## 基本合計値計算
   my $result = $base;


### PR DESCRIPTION
目標値つきのダイスロールをおこなったとき、その出目にかかわらず、“出目に補正値を適用した結果が目標値を満たしている”かぎりは「成功」と表示されていた。

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/7fb6fc0c-e9b5-435c-aa99-05439e555890)

（これは中立的なダイスロールコマンド機能という位置づけなので、これ単体で見ればおかしなことはない）

しかしながら、 SW2 のルール下において、この結果は明確に不適当であり、ルール上は失敗（自動失敗）となるのが正しい。
従来の挙動では、（出目の部分の色が変わるとはいえ）ルール的に正しくない「成功」の文字列の存在感がつよく、自動失敗の存在を見逃しかねない。

そこで、ゲームが SW2 であるかぎりにおいて、目標値つきダイスロールの自動失敗を検出して表示に反映するようにした。

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/aa0c8b46-37a8-4deb-a653-4b9831f33f84)

# 仕様

厳密には、次のすべての条件を満たすときに出目 1,1 を自動失敗とする。

* ゲームが SW2 である
* ダイスロールが 2D6 である（補正値の有無は問わない）
* `>=` または `>` による目標値指定がある

`>=` だけでなく `>` も考慮するのは、たとえば固定達成値の魔物に対する命中力判定など、“受動側の達成値が事前に判明しているうえで能動側が判定を試みる”場合において `2d+n>受動側の達成値` という運用をする可能性があるため。