### PR TITLE
重複ありランダム抽出コマンド（ `n$...` ）の結果を強調する

### DIFF
--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -414,6 +414,10 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   color: #888;
   text-decoration: none;
 }
+.logs dl dd.info.choice b.result {
+  background-color: #db52;
+  padding: 0 0.25em;
+}
 /* チャットログ：ダイス */
 .logs dl dd.info.dice::before {
   color: #f33;

--- a/lib/pl/read.pl
+++ b/lib/pl/read.pl
@@ -60,6 +60,11 @@ foreach($reverseOn ? (reverse <$FH>) : <$FH>) {
       #
       $_ =~ s#\{(.*?)\}#{<span class='division'>$1</span>}#g;
     }
+    elsif($system eq 'choice') {
+      if ($_ =~ /^\(.+\)\s+→\s+(.+?)$/) {
+        $_ =~ s#(\s+→\s+)(.+?)$#$1<b class='result'>$2</b>#;
+      }
+    }
     elsif($system =~ /^unit/){
       $_ =~ s# (\[.*?\])# <i>$1</i>#g;
     }


### PR DESCRIPTION
候補の数が多い場合など、候補リストを示す部分の文字列が長いとき、結果がどこなのかが一目してわかりづらかった。

**例：**
![image](https://github.com/yutorize/ytchat-adv/assets/44130782/aab98845-dc4d-406b-ba37-1a3498282910)

これを改善するために、結果を強調するようにした。

![image](https://github.com/yutorize/ytchat-adv/assets/44130782/865f8275-d38e-4086-a245-16fc87ac7a5c)
