### PR TITLE
任意項目ランダム選択機能（とランダム表機能）の抽出件数上限を 20 に変更

### DIFF
--- a/lib/pl/dice.pl
+++ b/lib/pl/dice.pl
@@ -248,7 +248,7 @@ sub shuffleRoll {
   my $rolls = my $rollsRaw = $1;
   my $faces = $2;
   my $modifier = $3;
-  my $max = 10;
+  my $max = 20;
   my $def = 1;
   if($set::random_table{$faces}){
     $max = $set::random_table{$faces}{'max'} || $max;
@@ -303,7 +303,7 @@ sub choiceRoll {
   my $rolls = my $rollsRaw = $1;
   my $faces = $2;
   my $modifier = $3;
-  my $max = 10;
+  my $max = 20;
   my $def = 1;
   if($set::random_table{$faces}){
     $max = $set::random_table{$faces}{'max'} || $max;

--- a/lib/pl/room.pl
+++ b/lib/pl/room.pl
@@ -154,7 +154,7 @@ foreach my $key (sort keys %set::random_table){
   push(@random_table, {
     'COMMAND'  => $key,
     'DEF' => $set::random_table{$key}{'def'} || 1,
-    'MAX' => $set::random_table{$key}{'max'} || 10,
+    'MAX' => $set::random_table{$key}{'max'} || 20,
     'HELP' => $set::random_table{$key}{'help'},
   });
 }


### PR DESCRIPTION
# 変更内容

「任意項目ランダム選択」の上限数を 10 から 20 に増加

# 背景

SW2.x の、「／Ｘ」形式の広範囲の効果を解決するに際して、その最大対象数を範囲内のキャラクター数が超える場合において、　10 よりも多くの数を抽選したいことがある。
このＸのルール上の最大値は 20 であるので、 20 までは一括で抽選したい。
（従来の挙動でも、ひとまず 10 件を抽選したのちに残りの候補から再抽選をすればいちおうは実現できたが、手間がかさむうえに結果が二箇所に散らばるのであまり好ましくない）

上記の例では、重複なし抽選のほうだけ上限数を拡張してもよかったのだが、対称性の観点から重複あり抽選のほうも同様に拡張した。

# 備考（2024/10/10 15:46 追記）

実装上、ランダム表も同じコードを経由するため、ランダム表にも影響がある。