### PR TITLE
ツールチップの `line-height` を固定する

### DIFF
--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -237,6 +237,7 @@ img.icon { width: 1em; height: 1em; }
   text-shadow: none;
   box-shadow: 3px 3px 3px #000a;
   font-size: 80%;
+  line-height: 1.8;
   z-index: 2;
   pointer-events: none;
   animation-name: tooltipfade;


### PR DESCRIPTION
_line-height_ に対するなんらかの指定のある要素（見出し記法など）の内側にツールチップがある場合において、ツールチップ内の _line-height_ が外側の要素の指定を継承してしまう問題への対処