### PR TITLE
Dropbox 上にあるアセットの URL の末尾が `dl=0` だったら `dl=1` に置き換えて解決する

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -2,9 +2,19 @@
 // UI
 // ------------------------------
 
+function resolveCloudAssetUrl(url) {
+  return resolveDropboxAssetUrl(resolveGoogleDriveAssetUrl(url));
+}
 function resolveGoogleDriveAssetUrl(url) {
   if(url.match(/^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/)){
     return `https://drive.google.com/uc?id=` + RegExp.$1;
+  }
+
+  return url;
+}
+function resolveDropboxAssetUrl(url) {
+  if (url.match(/^https?:\/\/www\.dropbox\.com\/.+[?&]dl=0$/)) {
+    return url.replace(/dl=0$/, 'dl=1');
   }
 
   return url;
@@ -1799,7 +1809,7 @@ function bgmPreviewPlay(url){
     ytPreview.loadVideoById(RegExp.$1);
   }
   else {
-    url = resolveGoogleDriveAssetUrl(url);
+    url = resolveCloudAssetUrl(url);
     console.log(url);
     playerA.style.display = '';
     playerY.style.display = 'none';
@@ -1908,7 +1918,7 @@ function bgmHistoryUpdate(){
 // 背景 ----------------------------------------
 function bgPreview(){
   let url = document.getElementById('bg-set-url').value;
-  url = resolveGoogleDriveAssetUrl(url);
+  url = resolveCloudAssetUrl(url);
   document.getElementById('bg-set-preview').src = url;
 }
 function bgHistoryUpdate(){
@@ -1950,7 +1960,7 @@ function bgInputSet(url, title, mode = null){
 // 挿絵 ----------------------------------------
 function imgPreview(){
   let url = document.getElementById('image-insert-url').value;
-  url = resolveGoogleDriveAssetUrl(url);
+  url = resolveCloudAssetUrl(url);
   document.getElementById('image-insert-preview').src = url;
 }
 function imgView(url){

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -895,13 +895,14 @@ sub paletteUpdate {
   close($FH);
 }
 
+# URL変換 ----------
 sub resolveCloudAssetUrl {
   my $url = shift;
   $url = resolveGoogleDriveAssetUrl($url);
   $url = resolveDropboxAssetUrl($url);
   return $url;
 }
-# GoogleドライブURL変換 ----------
+# Google
 sub resolveGoogleDriveAssetUrl {
   my $url = shift;
 
@@ -911,7 +912,7 @@ sub resolveGoogleDriveAssetUrl {
 
   return $url;
 }
-# Dropbox URL変換 ----------
+# Dropbox
 sub resolveDropboxAssetUrl {
   my $url = shift;
 

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -103,7 +103,7 @@ else {
   # 挿絵 ----------
   elsif($::in{'comm'} =~ s<^/insert\s+(https?://.+)><>i){
     my $url = $1;
-    $url = resolveGoogleDriveAssetUrl($url); # Google
+    $url = resolveCloudAssetUrl($url);
     $::in{'system'} = 'image';
     $::in{'comm'} = '';
     $::in{'info'} = $url;
@@ -143,7 +143,7 @@ else {
       }
       if(!$hit){ error('許可されていないURLです'); }
     }
-    $url = resolveGoogleDriveAssetUrl($url); # Google
+    $url = resolveCloudAssetUrl($url);
     bgmEdit($url,$title,$volume);
     $::in{'name'} = "!SYSTEM";
     $::in{'comm'} = "BGMを変更 by $::in{'player'}";
@@ -176,7 +176,7 @@ else {
       }
       if(!$hit){ error('許可されていないURLです'); }
     }
-    $url = resolveGoogleDriveAssetUrl($url); # Google
+    $url = resolveCloudAssetUrl($url);
     bgEdit($mode,$url,$title);
     $::in{'name'} = "!SYSTEM";
     $::in{'comm'} = "背景を変更 by $::in{'player'}";
@@ -895,12 +895,29 @@ sub paletteUpdate {
   close($FH);
 }
 
+sub resolveCloudAssetUrl {
+  my $url = shift;
+  $url = resolveGoogleDriveAssetUrl($url);
+  $url = resolveDropboxAssetUrl($url);
+  return $url;
+}
 # GoogleドライブURL変換 ----------
 sub resolveGoogleDriveAssetUrl {
   my $url = shift;
 
   if ($url =~ /^https?:\/\/drive\.google\.com\/file\/d\/(.+)\/view\?usp=(?:sharing|(?:share|drive)_link)$/) {
     return 'https://drive.google.com/uc?id=' . $1;
+  }
+
+  return $url;
+}
+# Dropbox URL変換 ----------
+sub resolveDropboxAssetUrl {
+  my $url = shift;
+
+  if ($url =~ /^https?:\/\/www\.dropbox\.com\/.+[?&]dl=0$/) {
+    $url =~ s/dl=0$/dl=1/;
+    return $url;
   }
 
   return $url;


### PR DESCRIPTION
よくある人為的ミスを機械的にケアする意図

（ `dl=1` じゃないとアセットそのものに対するアクセスにならないが、それを把握していないと／うっかりしていると `dl=0` 形式のＵＲＬを入力してしまうケースがある）