### PR TITLE
Fix: エラーメッセージに改行が含まれる場合に JSON の構造が壊れるのを回避

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -336,8 +336,7 @@ sub message {
 ## エラー
 sub error {
   if($in{'mode'} =~ /write|read|reset|change/){
-    my $message = $_[0];
-    $message =~ s/\n/\\n/g;
+    my $message = $_[0] =~ s/\n/\\n/gr;
     print "Content-type:application/json; charset=UTF-8\n\n";
     print '{"status":"error","text":"'.$message.'"}';
   }

--- a/index.cgi
+++ b/index.cgi
@@ -336,8 +336,10 @@ sub message {
 ## エラー
 sub error {
   if($in{'mode'} =~ /write|read|reset|change/){
+    my $message = $_[0];
+    $message =~ s/\n/\\n/g;
     print "Content-type:application/json; charset=UTF-8\n\n";
-    print '{"status":"error","text":"'.$_[0].'"}';
+    print '{"status":"error","text":"'.$message.'"}';
   }
   else {
     print "Content-type:text/plain; charset=UTF-8\n\n";


### PR DESCRIPTION
- ゆとチャはエラー発生時の結果を `application/json` を返す
- JSON の仕様として、文字列中の改行は `\n` で表すことになっている
- が、エラーメッセージ文字列がそのまま JSON の一部として埋め込まれていた
- ので、エラーメッセージ文字列に改行コードが含まれていると、 JSON としてパースできないものが `application/json` を名乗って返されることになってしまって、クライアント側で困る