### PR TITLE
メモを一覧からダイレクトに（ワンアクションで）拡大できるように

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -334,6 +334,40 @@ html,body {
 ---------------------------------------------------------------------------------------------------- */
 .memo ul#memo-list li {
   position: relative;
+  height: 2.2rem;
+  display: grid;
+  grid-template-rows: 100%;
+  grid-template-columns: max-content 1fr max-content;
+  align-items: center;
+  overflow-y: visible;
+
+  > .headline, .to-open {
+    grid-row: 1 / -1;
+  }
+
+  &::before {
+    grid-column: 1 / 2;
+  }
+
+  > .headline {
+    grid-column: 2 / 3;
+    height: max-content;
+  }
+
+  > .to-open {
+    grid-column: 3 / 4;
+    display: none;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 1.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: center;
+  }
+
+  &:hover > .to-open {
+    display: inline-flex;
+  }
 }
 .memo ul#memo-list li.removed {
   display: none !important;
@@ -349,6 +383,10 @@ html,body {
   font-size: 80%;
   line-height: 1;
   opacity: 0.6;
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
 }
 .memo .add.button {
   position: absolute;

--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -736,7 +736,7 @@ body {
 ---------------------------------------------------------------------------------------------------- */
 #memo {
   position: relative;
-  padding-bottom: 1.2em;
+  padding-bottom: 1.9em;
   overflow: auto;
   flex-shrink: 0;
 }
@@ -745,11 +745,13 @@ body {
 #memo ul#memo-list {
 }
 #memo ul#memo-list li {
+  border-bottom: .1rem solid var(--border-color-pale);
+}
+#memo ul#memo-list li > .headline {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   padding: .3em 0;
-  border-bottom: .1rem solid var(--border-color-pale);
 }
 [data-layout="row"] #memo {
   overflow: hidden;

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1215,8 +1215,7 @@ function memoUpdate(){
               event.preventDefault();
               event.stopPropagation();
 
-              memoSelect(memoIndex);
-              memoShowModal();
+              memoShowModal(memoIndex);
             };
           })(i)
       );
@@ -1246,9 +1245,14 @@ function memoModeChange(type){
   document.getElementById('sheet-unit-memo').dataset.memoMode = type;
   autosizeUpdate(document.getElementById("sheet-memo-value"));
 }
-function memoShowModal(){
+function memoShowModal(num = null){
   const dialog = document.getElementById('dialog-memo');
-  dialog.innerHTML = document.getElementById("memo-view").innerHTML;
+  if(num !== null){
+    dialog.innerHTML = tagConvert(shareMemo[num]);
+  }
+  else {
+    dialog.innerHTML = document.getElementById("memo-view").innerHTML;
+  }
   dialog.showModal();
 
   dialog.addEventListener("click", function memoCloseModal(e) {

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1183,13 +1183,45 @@ function memoUpdate(){
   for (let i in shareMemo) {
     shareMemo[i] ||= '';
     let newMemo = document.createElement('li');
-    newMemo.innerHTML = tagConvert( (shareMemo[i].split(/\n/))[0] ).replace(/<.+?>/g,'');
-    if (newMemo.innerHTML === '' && shareMemo[i].trim() === '') {
+
+    const memoHeadline = document.createElement('span');
+    memoHeadline.classList.add('headline');
+    memoHeadline.innerHTML = tagConvert( (shareMemo[i].split(/\n/))[0] ).replace(/<.+?>/g,'');
+
+    if (memoHeadline.innerHTML === '' && shareMemo[i].trim() === '') {
       newMemo.classList.add('removed');
     }
+
     newMemo.setAttribute("onclick","memoSelect("+i+");");
     newMemo.dataset.num = Number(i)+1;
     document.getElementById("memo-list").appendChild(newMemo);
+
+    if (memoHeadline.innerHTML !== '') {
+      newMemo.append(memoHeadline);
+
+      const buttonToOpen = document.createElement('button');
+      buttonToOpen.classList.add('to-open');
+      newMemo.append(buttonToOpen);
+
+      const openerIcon = document.createElement('span');
+      openerIcon.classList.add('material-symbols-outlined', 'icon');
+      openerIcon.textContent = 'open_with';
+      buttonToOpen.append(openerIcon);
+
+      buttonToOpen.addEventListener(
+          'click',
+          (memoIndex => {
+            return event => {
+              event.preventDefault();
+              event.stopPropagation();
+
+              memoSelect(memoIndex);
+              memoShowModal();
+            };
+          })(i)
+      );
+    }
+
     if(shareMemo[i]){ memoLength++ }
   }
   document.getElementById('memo').dataset.num = memoLength;


### PR DESCRIPTION
# 変更内容

メモ一覧に、任意のメモを拡大するボタンを追加

# 背景

拡大前のメモは、「画面の右端」に「狭い横幅」で表示されるため、テキストを読むには不自由することが多い。そのため、現実的にメモの内容を確認するにあたっては、拡大をともなう場合が多くある。

しかし、従来のＵＩでは、拡大したうえでのメモの確認には、「メモを選択する → 拡大する」という二段階の操作が必要となる。

これをより快適にするために、一覧からダイレクトに拡大できるようにしたい。

# 仕様

一覧内の各メモに、拡大ボタンを用意する。
![image](https://github.com/user-attachments/assets/57e0db80-4062-4141-8155-33884cdb8bdf)

一覧内の各メモの拡大ボタンをクリックすると、「メモを選択」＆「そのメモの拡大」を連続しておこなうのと等価の挙動をする。

ただし、一覧内のすべてに拡大ボタンを表示しておくと視覚的にかなりうるさいため、任意のメモにマウスオーバーしているあいだにかぎり、そのメモに対してのみ拡大ボタンを表示する。