### PR TITLE
カスタムCSSファイルへのアクセスにおいて、バージョン情報を付加する

### DIFF
--- a/lib/html/logs.html
+++ b/lib/html/logs.html
@@ -10,7 +10,7 @@
     @import url('./lib/css/logs.css?<TMPL_VAR ver>') layer(logs);
     @import url('./lib/css/config.css?<TMPL_VAR ver>');
   </style>
-  <TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>"></TMPL_IF>
+  <TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>?version=<TMPL_VAR customCSSVersion>"></TMPL_IF>
   <TMPL_UNLESS dlMode>
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jszip-utils@0.1.0/dist/jszip-utils.min.js"></script>

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -14,7 +14,7 @@
       
     @import url('https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css') layer(lib);
   </style>
-  <TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>"></TMPL_IF>
+  <TMPL_IF customCSS><link rel="stylesheet" media="all" href="<TMPL_VAR customCSS>?version=<TMPL_VAR customCSSVersion>"></TMPL_IF>
   <script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
   <script src="./lib/js/ui.js?<TMPL_VAR ver>" defer></script>

--- a/lib/pl/log-mold.pl
+++ b/lib/pl/log-mold.pl
@@ -442,6 +442,7 @@ if($error_flag){
 ###################
 ### CSS
 $ROOM->param(customCSS => $set::custom_css);
+$ROOM->param(customCSSVersion => (stat $set::custom_css)[9]) if $set::custom_css ne '';
 
 ###################
 ### 出力

--- a/lib/pl/room.pl
+++ b/lib/pl/room.pl
@@ -185,6 +185,7 @@ if($set::src_url_limit){
 $ROOM->param(srcURL => \@src_url);
 
 $ROOM->param(customCSS => $set::custom_css);
+$ROOM->param(customCSSVersion => (stat $set::custom_css)[9]) if $set::custom_css ne '';
 
 $ROOM->param(userRoomFlag => exists($set::rooms{$id}) ? 0 : 1);
 


### PR DESCRIPTION
組み込みの CSS にはゆとチャのバージョンがクエリパラメータとして付加されており、ゆとチャの更新時にキャッシュを参照しないようになっている。

しかし、カスタムCSSはそうではない。
そのこと自体は、カスタムCSSの更新サイクルはゆとチャの更新サイクルと異なるのであるから、適切である。

が、それはそれとして、カスタムCSSが更新されたときにキャッシュを参照しないための仕掛けはなかったので、それにあたるものを追加した。