### PR TITLE
Fix: ユーザー定義テキスト置換内の `&lt;`, `&gt;` がそれぞれ一度しか置換されない不具合を修正

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -144,7 +144,7 @@ sub tagConvert {
     foreach my $key (keys %{$hash}){
       my $value = ${$hash}{$key};
          $value =~ s/"/\\"/g;
-      $key =~ s/&lt;/</; $key =~ s/&gt;/>/;
+      $key =~ s/&lt;/</g; $key =~ s/&gt;/>/g;
       $comm =~ s/${key}/"\"${value}\""/gee;
     }
   }


### PR DESCRIPTION
_g_ 修飾子がなかった