### PR TITLE
Fix: 表組み記法が生成する table に outline と同量の margin を追加

### DIFF
--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -653,7 +653,7 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
 /* チャットログ：テーブル */
 .logs table,
 #topic table {
-  margin: .5em 0;
+  margin: calc(.5em + 1px) 1px;
   border-collapse: collapse;
   border-style: hidden;
   outline-width: 1px;
@@ -661,7 +661,7 @@ dd[data-stt*="侵蝕"] .gauge[data-signal="monster"] i::before { background: non
   outline-color: var(--border-color-deep);
 }
 #topic table {
-  margin: 0 0;
+  margin: 1px;
 }
 .logs table thead th,
 .logs table thead td,


### PR DESCRIPTION
表組み記法が生成する table の罫線の一部には、 outline がもちいられている。

ここで、 outline の幅は、要素の大きさには含まれない。

そのため、 outline の幅（ 1px ）の分だけ、本来よりも他の要素に近く表示されていた。

これを解消するため、 outline の幅と同じだけの margin を追加する。