### PR TITLE
ログの目次に、最新位置へジャンプするための項目を追加

### DIFF
--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -3,6 +3,7 @@
 // ------------------------------
 let mainTab = 1;
 var liteMode = Number(liteMode || localStorage.getItem('ytchatLiteMode') || 0);
+const isActive = new URLSearchParams(location.search).has('id');
 
 window.onload = function(){
   createTableOfContents();
@@ -135,6 +136,11 @@ function createTableOfContents(){
   console.log('createTableOfContents()');
   let num = 0;
   const ul = document.getElementById('toc-headline');
+  const lastHeadlineNode = document.createElement('a');
+  lastHeadlineNode.dataset.headline = '1';
+  lastHeadlineNode.textContent = `（${isActive ? "最新" : "末尾"}）`;
+  lastHeadlineNode.style.visibility = 'hidden';
+  [...document.querySelectorAll('#contents > .logs')].pop().appendChild(lastHeadlineNode);
   document.querySelectorAll(`[data-headline]`).forEach(obj => {
     const id = obj.id || 'headline-'+num;
     obj.id = id;

--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -138,7 +138,7 @@ function createTableOfContents(){
   const ul = document.getElementById('toc-headline');
   const lastHeadlineNode = document.createElement('a');
   lastHeadlineNode.dataset.headline = '1';
-  lastHeadlineNode.textContent = `（${isActive ? "最新" : "末尾"}）`;
+  lastHeadlineNode.textContent = `ログの${isActive ? "最新行" : "末尾"}`;
   lastHeadlineNode.style.visibility = 'hidden';
   [...document.querySelectorAll('#contents > .logs')].pop().appendChild(lastHeadlineNode);
   document.querySelectorAll(`[data-headline]`).forEach(obj => {


### PR DESCRIPTION
# 変更内容

ログの目次に、最新位置へジャンプするための項目を追加

# 背景と目的

ログ画面には、各見出し記法にジャンプするための目次がある。
が、これは見出し（とラウンド変更）にしかジャンプできなかった。

一方で、現実のゲームプレイにおいては、ログの末尾を確認したいというケースがそこそこある。
（典型的な例としては、「分割セッションにおいて、前回の最後の状況を確認したい」ケースや、「継続プレイにおいて、前回の最終結果（獲得報酬など）を確認したい」ケースなどがある）
そのようなケースにおいて、ログの末尾付近に見出しがあればよいのだが、最後の見出しから末尾までに少なからず距離（ログの長さ）が存在することもある。

なので、「見出しにかかわらず、とにかく末尾にジャンプする」という手段がほしい。

# 仕様

目次の生成において、ログの末尾に見出しがあるかのようにみなす。

表示名は、継続中のルームのログであれば `（最新）`、過去ログ化されているなら `（末尾）` とする。

# 表示例

![image](https://github.com/user-attachments/assets/b949879a-11a1-46b2-bec9-03f6b2c35edc)
