### PR TITLE
Fix: 内容が一定の条件を満たすとき、ログ画面における表組み記法が破綻する不具合に対処

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -175,7 +175,7 @@ sub tableCreate {
   my $row_num = 0;
   foreach my $row (@data){
     next if !@{$row};
-    $output .= "<tr data-test=@{$row}>";
+    $output .= "<tr>";
     my $col_num = 0;
     my $colspan = 1;
     foreach my $col (@{$row}){


### PR DESCRIPTION
デバッグ目的と推測されるコードが残っており、それが次のように、クォートで括ってもいなければエスケープもしていない可変文字列を HTML タグ内にもたらすので、内容によっては HTML が破綻していた。
```
$output .= "<tr data-test=@{$row}>";
```

---

例として、
```
| <em>傍点</em> |
```
という発言があった場合、
ログ画面では、
```
<table><tr data-test= <em>傍点</em> ><td> <em>傍点</em> </tr></table>
```
というめちゃくちゃな HTML が出力されている。

これを Google Chrome で閲覧すると、視覚的にも異常な表示がされる。
![image](https://github.com/user-attachments/assets/f236be20-d6ce-45ff-b007-2f1c9eebe514)
