### PR TITLE
チャットパレット内の変数名を右寄せで表示するのをやめる

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -573,7 +573,6 @@ body.rom .sheet { display: none !important; }
   flex-shrink: 1;
   position: relative;
   padding: .4rem 1rem .4rem .2rem;
-  text-align: right;
 }
 .sheet-body .chat-palette-frame .chat-palette.lines span.param b::after {
   content: '=';


### PR DESCRIPTION
チャットパレットの変数名部分について、これまでは右寄せのスタイルが設定されていた。

もっとも、原則的には変数名は必要なだけの幅しかとらないため、そのかぎりにおいては右寄せだろうがそうでなかろうが表示に差異はない。

差異があるのは、変数名があるていど以上に長い場合。
変数名が途中で折り返され、結果として要素幅に対してテキスト幅が小さくなるとき、右寄せであることがあらわになる。

![image](https://github.com/user-attachments/assets/4c16c6bf-3eca-4d65-8455-6d8f1047e190)
（「デクスタリティポーション」が右寄せで表示されている）

その変数単体で見た場合にはともかく、他の（右寄せであることがあらわになっていない）変数（※上の画像では「キャッツアイ」がそれに該当）と連続していると、テキストの左端が揃っていないように見えて、いさかか不自然なものがある。
このことをふまえ、またとくに右寄せでなければならない理由もなさそうなので、右寄せをやめる。