### PR TITLE
ログ画面の目次において、ルビを維持する

### DIFF
--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -144,8 +144,10 @@ function createTableOfContents(){
     anchor.href = '#'+id;
     anchor.innerHTML = obj.innerHTML
                         .replace(/<br>/gi,' ')
+                        .replace(/<ruby><rp>｜<\/rp>(.+?)<rp>《<\/rp><rt>(.+?)(<\/rt>)?<rp>》<\/rp><\/ruby>/g, '{[ruby|$1|$2]}')
                         .replace(/<.+?>/g,'')
                         .replace(/:([a-z0-9_]+?):/g,'<span class="material-symbols-outlined"><i>:</i>$1<i>:</i></span>')
+                        .replace(/\{\[ruby\|(.+?)\|(.+?)]}/g, '<ruby>$1<rt>$2</rt></ruby>')
                         .trim();
     li.append(anchor);
     ul.append(li);


### PR DESCRIPTION
ログ画面の目次においては、 Material Symbols 以外のタグはすべて消し飛ばされていたため、元の見出しにルビが含まれる場合に間の抜けた感じになっていた。

![image](https://github.com/user-attachments/assets/76290507-91c9-46e4-97e9-c74d505e0925)

ルビくらいは残ったほうがいいような気がするので、ルビを維持するようにしてみる。

---

実装がめちゃくちゃ雑なので、もっとちゃんと実装したほうがいい可能性があります。