### PR TITLE
ルーム一覧におけるログへのハイパーリンクの表現を変更

### DIFF
--- a/lib/css/list.css
+++ b/lib/css/list.css
@@ -46,6 +46,12 @@ table.list tbody td a {
   display: block;
   margin: -.5em -1em;
   padding: .5em 1em;
+
+  &.log::before {
+    content: "\ef42";
+    font-family: "Material Symbols Outlined", sans-serif;
+    font-variation-settings: 'FILL' 1;
+  }
 }
 table.list tbody a:link {
   background: none;

--- a/lib/html/list.html
+++ b/lib/html/list.html
@@ -119,7 +119,7 @@
     </TMPL_IF>
     <table class="list">
       <thead><tr><th>ゲームルーム名</th><th>ゲームシステム</th><th>ログ</th><th>ログサイズ</th></tr></thead>
-      <TMPL_LOOP List><tr><th><a href="./?mode=room&id=<TMPL_VAR ID>"><TMPL_VAR NAME></a></th><td><TMPL_VAR GAME></td><td><a href="./?mode=logs&id=<TMPL_VAR ID>">▶</a></td><td><TMPL_VAR SIZE></td></tr></TMPL_LOOP>
+      <TMPL_LOOP List><tr><th><a href="./?mode=room&id=<TMPL_VAR ID>"><TMPL_VAR NAME></a></th><td><TMPL_VAR GAME></td><td><a class="log" href="./?mode=logs&id=<TMPL_VAR ID>"></a></td><td><TMPL_VAR SIZE></td></tr></TMPL_LOOP>
       <tfoot><tr style="border:none;"><td colspan="4" class="right" style="padding:1rem 0"><a href="./?mode=logs">>>ログ一覧</a></td></tr></tfoot>
     </table>
   </article>


### PR DESCRIPTION
いままで `▶` と表示されていた部分を、よりログっぽいアイコンに変える。

![image](https://github.com/user-attachments/assets/12187f9d-91cd-473d-b856-65d2e9828c2d)

「▶」のように表示していたのは、ログを“再生する”というニュアンスだったのかと思うが、一般的に“ログ”に「▶」のような記号が当てられることはない。
また、“再生する”ニュアンスで「▶」をもちいる場合、その再生は半自動的に進行することが一般的には期待されるはずなので、やはりゆとチャのログ機能には適切でないと考える。
（いわゆるノベルゲームですら、「▶」表現は「自動ページ送り」のような機能に割り当てるのがふつうで、「ログ」機能に割り当てることはないはず）