### PR TITLE
発言欄下の行動済みチェックボタンに対象ユニット名を明示する

### DIFF
--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -505,6 +505,10 @@ body {
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
+      
+      @media screen and (width < 1425px) {
+        display: none;
+      }
     }
   }
 }

--- a/lib/css/chat-layout-pc.css
+++ b/lib/css/chat-layout-pc.css
@@ -491,6 +491,22 @@ body {
   width: max-content;
   border-top: 0;
   border-radius: 0 0 .8rem .8rem;
+
+  > span[data-unit-name]:not([data-unit-name=""]) {
+    display: inline-flex;
+    align-items: center;
+    height: max-content;
+
+    &::after {
+      content: ":" attr(data-unit-name);
+      display: inline-block;
+      max-width: 10em;
+      height: max-content;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  }
 }
 .check-buttons button::before {
   content: '✔';

--- a/lib/html/room.html
+++ b/lib/html/room.html
@@ -123,7 +123,7 @@
           </div>
           
           <div class="check-buttons">
-            <button onclick="unitCheckSubmit()"><span class="small">行動済</span></button>
+            <button onclick="unitCheckSubmit()"><span>行動済</span></button>
           </div>
           <div class="form-dice" id="form-dice-0">
             <span class="del edit button" onclick="diceDel(0);" title="ダイス欄を削除">－</span>

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -578,6 +578,9 @@ function checkButtonMainVisibleToggle(){
   const nameNum = document.getElementById('form-name').value || 0;
   const name = nameList[nameNum]['name'];
   document.querySelector('#main-form .check-buttons').style.visibility = unitList[name] ? 'visible' : 'hidden';
+  if (unitList[name] != null) {
+    document.querySelector('#main-form .check-buttons button span').dataset.unitName = name;
+  }
   document.querySelector('#main-form .check-buttons button').classList.toggle('checked', unitList[name] && unitList[name]['check'])
 }
 // 色変更 ----------------------------------------


### PR DESCRIPTION
# 変更内容

発言欄下の行動済みチェックボタンに、対象のユニットの名称を明示する

# 変更理由

当該ボタンは、感覚的にも位置的にもユニットから大きく離れており、ユニットに作用するということがいまひとつ直感的ではない。

そして、「何が起こるのかよくわからないボタン」は押す気にならない。
とくに、プレイヤー名で入室している場合、なおのこと「プレイヤーに作用したらめんどい」という意識がはたらきやすい。

# 表示例
![image](https://github.com/user-attachments/assets/ce14fcda-665f-4763-8609-bf7c2e0a13b2)

# 備考
`class="small"` が指定されているとユニット名の文字が潰れがちだったので、外した。