### PR TITLE
Fix: SW2.5 向けのテキスト置換定義 `[>>]` が正しく解決されない不具合に対処

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -144,7 +144,13 @@ sub tagConvert {
     foreach my $key (keys %{$hash}){
       my $value = ${$hash}{$key};
          $value =~ s/"/\\"/g;
-      $key =~ s/&lt;/</g; $key =~ s/&gt;/>/g;
+      if ($key =~ /[<>]/) {
+        $key =~ s/</&lt;/g;
+        $key =~ s/>/&gt;/g;
+      } else {
+        $key =~ s/&lt;/</g;
+        $key =~ s/&gt;/>/g;
+      }
       $comm =~ s/${key}/"\"${value}\""/gee;
     }
   }

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -987,7 +987,7 @@ function tagConvert (comm){
   });
   replaceRegex.forEach(item => {
     for (const [key, value] of Object.entries(item)) {
-      comm = comm.replace(new RegExp(key,'gu'), value);
+      comm = comm.replace(new RegExp(key.replaceAll(/</g, '&lt;').replaceAll(/>/g, '&gt;'),'gu'), value);
     }
   });
   


### PR DESCRIPTION
# 現象

`[>>]` が適切にアイコンに置換されず、そのまま表示されていた。

![image](https://github.com/user-attachments/assets/4deb85c7-edb7-4ef4-92b2-3b674e3d67ee)

# 原因

仕様上、置換定義上では `&gt;` と表記しなければならないが、 `>` と表記されていたため。

# 対処

`<` または `>` が含まれる置換定義は、それぞれ `&lt;`, `&gt;` に置き換えて解決する。

## この対処方法をとった理由

- `[>>]` の定義は config.cgi.default 内にあり、もはや各所の環境ではこれを複製した config.cgi が存在するであろうことから、 config.cgi.default 側を書き換えたところで反映されない
- 置換定義上で `&lt;`, `&gt;` をもちいて記述するのは実際かなりダルい