### PR TITLE
12時間以上前のタイムスタンプには日付も表示する

### DIFF
--- a/lib/pl/read.pl
+++ b/lib/pl/read.pl
@@ -5,6 +5,7 @@ use open ":utf8";
 use open ":std";
 use Encode qw/encode decode/;
 use JSON::PP;
+use Time::Piece;
 
 ###################
 ### 読み込み処理
@@ -19,6 +20,7 @@ if(!$::in{'loadedLog'}){
   my $allsize = -s $dir.'log-all.dat';
   if($allsize > $presize){ $logfile = 'log-all.dat'; $reverseOn = 1; }
 }
+my $now = localtime;
 my @lines; my %palette;
 open(my $FH, '<', $dir.$logfile) or error "${logfile}が開けません";
 foreach($reverseOn ? (reverse <$FH>) : <$FH>) {
@@ -36,7 +38,8 @@ foreach($reverseOn ? (reverse <$FH>) : <$FH>) {
     last if ($::in{'num'} > $num - 1);
   }
   #
-  my (undef, $time) = split(/ /, $date);
+  my $timePiece = Time::Piece->strptime($date, '%Y/%m/%d %H:%M:%S');
+  my $time = $timePiece->strftime($now->epoch - $timePiece->epoch > 60 * 60 * 12 ? '%Y/%m/%d %H:%M:%S' : '%H:%M:%S');
   my ($username, $userid) = $user =~ /^(.*)<([0-9a-zA-Z]+?)>$/;
   my $game;
   my $code;


### PR DESCRIPTION
# 変更内容

12時間以上前のタイムスタンプには日付も表示する
（厳密には、“取得時に”12時間以上前のものに対して）

# 背景

従来は、タイムスタンプには「時：分：秒」のみが表示されていた。

しかし、複数日に分割されたセッション、“置き卓”、セッション外でそれぞれが流動的な時間でキャラクター作成をするなど、「認識していない（または忘却した）ところでの発言」を後から確認する場合に、日付を意識したいことがたまにある。

そういった需要を満たすために、取得時点で12時間以上前のタイムスタンプには、日付も含めるように。

なお、「取得時点で」とするのは、

- ひとたび表示してから時間経過で日付を追加しようとすると、 JS でいろいろやることになるので、とりあえず簡易的に実装できる方法として
- ルームを開いている状態で流れるログについては、リアルタイムに見ている場合がそれなりに多いため、日付がなくてもまあまあ問題がない

という理由による。