### PR TITLE
背景プリセットのサムネイルがクラウドストレージ上にあるケースをサポート

### DIFF
--- a/lib/pl/room.pl
+++ b/lib/pl/room.pl
@@ -166,6 +166,7 @@ foreach (@set::bg_preset){
   my $mode = @$_[3] || '';
   if($set::bg_thum_on){
     my $src = @$_[2] || @$_[0];
+    $src = resolveCloudAssetUrl($src, 'log');
     push(@bg_list, { 'URL' => @$_[0], 'MODE' => $mode, 'TITLE' => @$_[1], 'VIEW' => "<img loading=\"lazy\" src=\"${src}\"><div class=\"title\">@$_[1]</div>" });
   }
   else { push(@bg_list, { 'URL' => @$_[0], 'MODE' => $mode, 'TITLE' => @$_[1], 'VIEW' => @$_[1] }); }


### PR DESCRIPTION
アセット本体はクライアント上で表示するときに特殊な URL が解決されるようになっていたが、サムネイルはそうではなかった（のを、改善した）