### PR TITLE
BCDice-API v2 対応

### DIFF
--- a/lib/html/list.html
+++ b/lib/html/list.html
@@ -44,7 +44,7 @@
     }
     const select = document.getElementById('set-bcdice-game');
     Promise.race([
-      fetch(apiUrl+'/v1/names', {
+      fetch(apiUrl+'/v2/game_system', {
         method: "GET",
         cache: 'no-cache'
       }),
@@ -53,7 +53,7 @@
     .then(response => response.text())
     .then( json => {
       const data = JSON.parse(json);
-      data['names'].sort(function(a,b){
+      data['game_system'].sort(function(a,b){
         if(a.name < b.name) return -1;
         if(a.name > b.name) return 1;
         return 0;
@@ -61,10 +61,10 @@
       while (0 < select.childNodes.length) {
         select.removeChild(select.childNodes[0]);
       }
-      for(let key in data['names']){
+      for(let key in data['game_system']){
         let op = document.createElement("option");
-        op.text = data['names'][key]['name'];
-        op.value = data['names'][key]['system'];
+        op.text = data['game_system'][key]['name'];
+        op.value = data['game_system'][key]['id'];
         select.appendChild(op);
       }
     })

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -188,14 +188,14 @@ window.addEventListener('load', function() {
 function bcdiceGet(apiUrl, set){
   console.log('BCDiceGet >> API: '+apiUrl);
   const select = document.getElementById('config-room-bcdice-game');
-  fetch(apiUrl+'/v1/names', {
+  fetch(apiUrl+'/v2/game_system', {
     method: "GET",
     cache: 'no-cache',
   })
   .then(handleErrors)
   .then(response => response.json())
   .then(data => {
-    data['names'].sort(function(a,b){
+    data['game_system'].sort(function(a,b){
       if(a.name < b.name) return -1;
       if(a.name > b.name) return 1;
       return 0;
@@ -203,11 +203,11 @@ function bcdiceGet(apiUrl, set){
     while (0 < select.childNodes.length) {
       select.removeChild(select.childNodes[0]);
     }
-    for(let key in data['names']){
+    for(let key in data['game_system']){
       let op = document.createElement("option");
-      op.text = data['names'][key]['name'];
-      op.value = data['names'][key]['system'];
-      if(bcdiceSystem === data['names'][key]['system']){
+      op.text = data['game_system'][key]['name'];
+      op.value = data['game_system'][key]['id'];
+      if(bcdiceSystem === data['game_system'][key]['id']){
         op.selected = true;
       }
       select.appendChild(op);


### PR DESCRIPTION
# 変更内容

BCDice-API の利用時に、 v2 を参照するように変更。
v1 と v2 の仕様の差異に対応。

# 背景

今年の２月ごろに、 BCDice-API は v1 の提供を終了している。（ https://github.com/bcdice/bcdice-api/releases/tag/3.0.0 ）
しかし、ゆとチャは v1 を参照して動作している箇所があった。
そのため、現在においては、ゆとチャから BCDice-API を利用するとき、問題が生じていた。

この状況を解消すべく、 v2 を利用するように変更する。

# 詳細

v1 時代の `/names` は廃止され、ほぼ相当のものが `/game_system` として提供されているので、それを利用するように。
また、かつて `system` だったフィールドが `id` に変わっているようなので、そこも変更する。

![image](https://github.com/user-attachments/assets/07d8b187-2eee-4b86-a2b4-dc04f28e459f)
（ https://github.com/bcdice/bcdice-api より）

