### PR TITLE
ステータスリモコンにおいて、 HP と MP の入力欄は色味を変えるように

### DIFF
--- a/lib/css/chat-common.css
+++ b/lib/css/chat-common.css
@@ -1137,6 +1137,24 @@ body.rom .input-form { display: none !important; }
   border-color: transparent;
   overflow: hidden;
 }
+.dice-button[data-kind="HP"] {
+  input, textarea {
+    background-color: rgb(18, 46, 43);
+
+    &:focus {
+      background-color: rgb(32, 59, 51);
+    }
+  }
+}
+.dice-button[data-kind="MP"] {
+  input, textarea {
+    background-color: rgb(19, 18, 45);
+
+    &:focus {
+      background-color: rgb(33, 31, 59);
+    }
+  }
+}
 .dice-button button:only-child {
   grid-column: span 2;
   border-radius: .5em;

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -883,6 +883,26 @@ function unitRemoconAdd(unitName,status,value){
       <textarea class="form-comm" name="stt-${i}" id="edit-stt-${unitId}-${i}-value" data-comm-status="${i}" data-palette-target='${unitNameEscaped}' rows="1" placeholder="値">${value||''}</textarea>
       <button onclick="formSubmit('edit-stt-${unitId}-${i}-value','${unitNameEscaped}');"></button>
     </li>`);
+
+  const nameInput = document.getElementById(nameInputId);
+  nameInput.addEventListener(
+      'input',
+      event => {
+        /** @var {HTMLInputElement} */
+        const input = event.target;
+        const container = input.closest('.dice-button');
+        const statusName = input.value?.trim() ?? '';
+
+        if (statusName.endsWith('HP')) {
+          container.dataset.kind = 'HP';
+        } else if (statusName.endsWith('MP')) {
+          container.dataset.kind = 'MP';
+        } else {
+          delete container.dataset.kind;
+        }
+      }
+  );
+  nameInput.dispatchEvent(new Event('input'));
 }
 function unitRemoconDel(unitName){
   const unitId = unitList[unitName]['id'];

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -876,9 +876,10 @@ function unitRemoconAdd(unitName,status,value){
     i++;
   }
   if(!unitList[unitName]['sttnames']){ unitList[unitName]['sttnames'] = []; }
+  const nameInputId = `edit-stt-${unitId}-${i}-name`;
   document.querySelector(`#sheet-unit-${unitId} .status-remocon-list`).insertAdjacentHTML('beforeend',`
     <li class="dice-button">
-      <input id="edit-stt-${unitId}-${i}-name" value="${status||unitList[unitName]['sttnames'][i]||''}" placeholder="ラベル">
+      <input id="${nameInputId}" value="${status||unitList[unitName]['sttnames'][i]||''}" placeholder="ラベル">
       <textarea class="form-comm" name="stt-${i}" id="edit-stt-${unitId}-${i}-value" data-comm-status="${i}" data-palette-target='${unitNameEscaped}' rows="1" placeholder="値">${value||''}</textarea>
       <button onclick="formSubmit('edit-stt-${unitId}-${i}-value','${unitNameEscaped}');"></button>
     </li>`);


### PR DESCRIPTION
# 変更内容

ステータスリモコンにおいて、 HP と MP の入力欄は色味を変えるように。

# 背景と目的

『SW2』のプレイ中、ステータスリモコンの操作に際して、 HP と MP を取り違えてしまう事例がちょくちょく発生していた。
（ HP のつもりで MP を操作してしまうケース。あるいはその逆）

とくに、複数部位のキャラクターにおいて起こりやすかった。
（おそらく、ステータス項目数が多いことと、各ステータス項目名に部位の名称が含まれるせいで HP / MP の存在感が相対的にちいさくなることが原因と考えられる）

そのようなミスを減らすべく、より感覚的に HP なのか MP なのかを識別できるように、 HP または MP をあらわすステータス項目は、色味を変えることにする。

# 仕様

- ステータス項目名の末尾が `HP` であれば、 HP をあらわす項目とみなす
- ステータス項目名の末尾が `MP` であれば、 MP をあらわす項目とみなす

# 備考

具体的な色味の設定は、元の input の色味をベースに、ユニット一覧における HP の（ safe の）色と MP の色を一定の割合で合成したうえで、明度が元の input の色と一致するように調整したものにしてある。

# 表示例
![image](https://github.com/user-attachments/assets/bba7c848-d978-4a70-a1ee-55d179863efd)
