### PR TITLE
Fix: ＢＧＭの存在するログ画面を開いてＢＧＭ再生についてのダイアログを操作したときにエラーが発生する場合があるのを修正

### DIFF
--- a/lib/js/logs.js
+++ b/lib/js/logs.js
@@ -343,6 +343,12 @@ function onYouTubePlayerAPIReady() {
       'onReady': ytPlayerReady
     }
   });
+
+  if (muteOn) {
+    soundOff();
+  } else {
+    soundOn();
+  }
 }
 let ytPlayerReadyOk = 0;
 function ytPlayerReady(){
@@ -482,8 +488,8 @@ function soundOn(){
   console.log('soundOn');
   document.getElementById('option-mute-button').classList.remove('muted');
   bgMusic.muted = false;
-  ytPlayer.unMute();
-  ytPlayer.playVideo();
+  ytPlayer?.unMute();
+  ytPlayer?.playVideo();
   muteOn = 0;
   if(bgMusics[currentBgm]['url'].match(/^https:\/\/youtu\.be\/(.+)$/)){
     ytPlayerArea.style.display = 'block';
@@ -493,8 +499,8 @@ function soundOff(){
   console.log('soundOff');
   document.getElementById('option-mute-button').classList.add('muted');
   bgMusic.muted = true;
-  ytPlayer.mute();
-  ytPlayer.pauseVideo();
+  ytPlayer?.mute();
+  ytPlayer?.pauseVideo();
   muteOn = 1;
   ytPlayerArea.style.display = 'none';
 }


### PR DESCRIPTION
# 現象

`soundOff()`, `soundOn()` 内における `ytPlayer` が undefined となっており、 undefined 参照が発生する（ことがある）。

# 再現方法

ＢＧＭの存在するログ画面を開き、ＢＧＭの再生確認ダイアログに対して、すみやかに ON または OFF の操作をする。
……と、**場合によってはたまに**発生する。

# 原因

[`onYouTubeIframeAPIReady()`](https://developers.google.com/youtube/iframe_api_reference?hl=ja) が呼び出されるより先に `window.onload` が解決されるケースがあるっぽい。

`onYouTubeIframeAPIReady()` が厳密にいつ呼び出されるのかは YouTube 側の実装に依るので定かではないが、起きている現象からすると、 iframe としての読み込みが完了（ iframe の onload 相当）がして（※この時点で親の window としては load が完了したものと認識してしまう）から `onYouTubeIframeAPIReady()` を呼び出すまでに時間差が生じるケースがある？

すくなくとも、 console のログ（↓）を見るかぎり、そういう順序になっているっぽい
![image](https://github.com/user-attachments/assets/2b3248ce-b5b2-4738-a83d-b4a1b167759d)

# 対策

- `soundOff()`, `soundOn()` 内では optional chaining `?.` をもちいて undefined のケースを考慮する。
- `onYouTubeIframeAPIReady()` 内から、 `muteOn` の状態にもとづいて `soundOff()`, `soundOn()` を呼び出す。
