### PR TITLE
Fix: ログ画面でキャラクター画像のURLが正しくない不具合を修正

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -196,7 +196,7 @@ sub tagConvertUnit {
   my $comm = shift;
   $comm =~ s/<br>/\n/g;
 
-  $comm =~ s#<chara-image:(https?:\/\/[^\s\<]+)(?:,(.+?))(?:,(.+?))>#<div class="chara-image" style="background-image:url($1>);background-size:$2;background-position:$3;"></div>#g;
+  $comm =~ s#<chara-image:(https?:\/\/[^\s\<]+)(?:,(.+?))(?:,(.+?))>#<div class="chara-image" style="background-image:url($1);background-size:$2;background-position:$3;"></div>#g;
   $comm =~ s#\[\[(.+?)>(https?:\/\/[^\s\<]+)\]\]#<a href="$2" target="_blank">$1</a>#g;
   $comm =~ s#((?:\G|>)[^<]*?)(https?://[^\s\<]+)#$1<a href="$2" target="_blank">$2</a>#g;
 


### PR DESCRIPTION
URLの末尾に余計な `>` がついていた。

なお、キャラクター読み込み元がゆとシートの場合は、 URL が `https://example.com/ytsheet/{GAME}/?id={ID}&mode=image&cache={TIMESTAMP}` のような形式であり、この末尾に `>` がついても `cache` パラメータがおかしくなるだけで済むため、（すくなくとも表向きは）問題なく動作する。