### PR TITLE
チャットパレットから現在のラウンド数を変数記法で参照できるように

### DIFF
--- a/lib/css/config.css
+++ b/lib/css/config.css
@@ -162,6 +162,10 @@
     color: #99eecc;
     font-style: normal;
   }
+  .chat-palette i.room-status {
+    color: #eecc99;
+    font-style: normal;
+  }
 }
 
 /* // カラー設定：チャット

--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1999,6 +1999,8 @@ function paletteValueList(id){
       arr.push(`//${statusName}=${currentValue}`)
     }
   }
+  // ルーム変数
+  arr.push(`//ROUND=${document.getElementById('round-value').textContent.trim()}`);
 
   return arr;
 }

--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1171,6 +1171,7 @@ function paletteLineParamReplace(id,text){
       if     (varName in diceParams)       { return `<i class="dice-param">${raw}</i>` }
       else if(varName in paletteParams[id]){ return `<i class="palette-param">${raw}</i>` }
       else if(unitStatusNames.includes(varName)){ return `<i class="unit-status">${raw}</i>` }
+      else if(['ROUND'].map(x => x.toLowerCase()).includes(varName)){ return `<i class="room-status">${raw}</i>` }
       else { return raw };
     })]
   }


### PR DESCRIPTION
# 変更内容

チャットパレットから現在のラウンド数を変数記法で参照できるように

# 背景と目的

ゲームによっては、「現在のラウンド数」を参照する処理が存在する。

メジャーなタイトルの一例としては、『銀剣のステラナイツ』が挙げられる。
『ステラナイツ』には、ラウンドごとの「チャージ判定」（同書P.140）というルールが存在し、これには“「キャラクターごとの固定値＋現在のラウンド数」のダイスを振る”という処理が含まれている。これはすべてのステラナイト（いわゆるＰＣに相当）が毎ラウンドかならずおこなう処理であり、ゲームの場における発生頻度が一定程度に高い。
また『ステラナイツ』には他にも、ラウンド数を参照する効果の「スキル」が多数存在する（収録されている構築済みキャラクターデータでいうと、３分の２ほどのステラナイトがそのようなスキルを有している）。

こうしたゲームのプレイでは、チャットパレット上で「現在のラウンド数」を参照したい需要が大きく存在する。
手作業でそのような変数を設けることもむろん可能ではあるものの、ルーム自体のラウンド数と合わせて二重管理となり、ラウンドの推移に応じて値を更新することを忘れやすいという問題があるため、ルーム側のもっているラウンド数を参照できるようにしたい。

# 仕様

`{ROUND}` と記述すると、現在のラウンド数を参照できる。

![image](https://github.com/user-attachments/assets/26f44132-33de-49e6-8230-3dedeca2bea2)
