### PR TITLE
四則演算コマンドにおいて、等号の前のスペースを許容するように

### DIFF
--- a/lib/pl/dice.pl
+++ b/lib/pl/dice.pl
@@ -27,7 +27,7 @@ sub diceCheck {
     ( \(? \-? [0-9.]+ [\+\-\/*\^]
       [0-9.\+\-\/*\^()]*
       [0-9.] \)? )
-    [=＝](?:\s|$)
+    \s*[=＝](?:\s|$)
     /ix){
     my $formula = $1;
     if($formula !~ /[\+\-\/\*\^]/) { return ''; }
@@ -37,7 +37,7 @@ sub diceCheck {
     $formula_perl =~ s#\*\*#\^#g;
     my $result = eval($formula);
     if($result eq ''){ return ''; }
-    return "${formula_perl} = ${result}", 'dice';
+    return "${formula_perl} = ${result}", 'dice:calc';
   }
   # SW2
   elsif($::in{'game'} eq 'sw2'){

--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -336,6 +336,7 @@ sub diceCodeCheck {
     ($::in{'info'}, $::in{'system'}) = diceCheck($::in{'comm'});
     if($::in{'info'}){
       $::in{'comm'} =~ s/^(.*?(?:\s|$))//;
+      $::in{'comm'} = '' if $::in{'system'} eq 'dice:calc' && $::in{'comm'} =~ /^[=＝]$/;
       $::in{'info'} .= '<<'.$1;
       return $::in{'info'};
     }


### PR DESCRIPTION
`3+4 =` のような入力を許容する。

等号の前にスペースのあるケースがそこそこ頻発しており、そしてコマンドとして解決されない理由（スペースの存在）に気づきづらいため。


