### PR TITLE
Fix: マスタボリュームやＢＧＭボリュームを変更しても再生中のＢＧＭプレビューには反映されない不具合を修正

### DIFF
--- a/lib/js/ui.js
+++ b/lib/js/ui.js
@@ -1726,6 +1726,11 @@ document.querySelectorAll('#config-sound input[type="range"]').forEach(obj => {
     document.getElementById(obj.id+'-view').innerHTML = obj.value+'%';
     if(type === 'bgm' || type === 'master') {
       bgmVolumeSet();
+
+      if (audioPreview.src != null && audioPreview.src !== '') {
+        // プレビューのボリュームを更新する.
+        document.getElementById('bgm-set-volume').dispatchEvent(new Event('input'));
+      }
     }
     else if(type !== 'master') {
       const se = new Audio( type == 'chat' ? (config.seType['chat1']||defSeType['chat']) : config.seType[type] );


### PR DESCRIPTION
# 現象

サウンド設定の変更が、すでに再生されているプレビューには反映されてなかった。

# 対処

サウンド設定の変更時、プレビューのボリュームを再設定させる。
