### PR TITLE
Fix: ステータス操作コマンドで括弧が使えなくなっていたのを修正

### DIFF
--- a/lib/pl/write.pl
+++ b/lib/pl/write.pl
@@ -300,7 +300,7 @@ else {
       (
         (?:$stt_commands|メモ|memo|url)
         (?:
-          (?:[\+＋\-－\*＊\/／=＝] [\+＋\-－\*＊\/／=＝0-9０-９dｄDＤ]*?)
+          (?:[\+＋\-－\*＊\/／=＝] [\+＋\-－\*＊\/／=＝0-9０-９dｄDＤ（）()]*?)
           |
           (?:[:：] (?:"(?:.*?)"|(?:.*?)))
         )
@@ -859,7 +859,7 @@ sub unitCalcEdit {
   seek($FH, 0, 0);
   
   my $result_info; my $result_system; my $memo_flag; my $url_flag;
-  $set_text =~ tr/０-９＋－÷＊＝：！/0-9\+\-\/\*=:!/;
+  $set_text =~ tr/０-９＋－÷＊＝：！（）/0-9\+\-\/\*=:!()/;
   while($set_text =~ s/^($stt_commands|メモ|memo|url)([+\-\*\/=\:])(?:"(.*?)"|(.*?))(?:\s|$)//s){
     my ($type, $op, $text, $num) = ($1,$2,$3,$4);
     # メモ
@@ -887,7 +887,7 @@ sub unitCalcEdit {
     else {
       if($num eq '' && $text){ $num = $text; }
       my $rolledText;
-      if($op =~ /^[+\-\*\/=]$/ && $num =~ /^[+\-\*\/0-9\.d]+$/i){
+      if($op =~ /^[+\-\*\/=]$/ && $num =~ /^[+\-\*\/0-9\.d()]+$/i){
         $num = parenthesisCalc($num);
         ($num, $rolledText) = diceInStatusCommand($num);
         my ($result, $diff, $over) = sttCalc($type,$num,$op,$data{'unit'}{$set_name}{'status'}{$type});


### PR DESCRIPTION
# 変更内容

ステータス操作コマンドで括弧を利用できるように。
（過去においては利用できていたが、特定のバージョンから利用できなくなっていた）

これにより、たとえば `@HP-(5+1)*2` のようなコマンドが（ふたたび）使えるようになる。

# 原因

a1a3819a6a9a6b1740c0d24ca50c3035b1a2ef2f で、括弧が考慮されていなかったっぽい。

# 用例

たとえば『SW2.5』において、「【マジシャン】（⇒『Ⅱ』158頁）による《ＭＰ軽減／＊＊》（⇒『Ⅰ』283頁）の習得」や「〈ブラックロッド〉（⇒『Ⅱ』254頁）の装備」などの、一時的にのみ有効になるＭＰ消費の軽減効果があるとき、

```
//MP軽減=1
@MP-(6-{MP軽減})*3 【フォッシルアブソーバー】（１体Ｘ）toシザースコーピオン（３部位）のＰＣ
```

というような活用ができる。
