### PR TITLE
Fix: 発言の中に `undefined` という文字列が含まれると正しい内容で送信されない不具合を修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1699,17 +1699,19 @@ function nameCheck(name, comm){
     reg2 = new RegExp("^("+after+")((?:"+status.join('|')+")|メモ|memo|check|delete|new|add)?");
     return after;
   });
-  // ステータス
-  newComm = newComm.replace(reg2, function(whole, atMark, mStatus){
-    let after = '';
-    if(mStatus){
-      after = '@'+mStatus;
-    }
-    else {
-      after = atMark;
-    }
-    return after;
-  });
+  if (reg2 != null) {
+    // ステータス
+    newComm = newComm.replace(reg2, function(whole, atMark, mStatus){
+      let after = '';
+      if(mStatus){
+        after = '@'+mStatus;
+      }
+      else {
+        after = atMark;
+      }
+      return after;
+    });
+  }
   return [name, newComm];
 }
 function escapeRegExp(str) {


### PR DESCRIPTION
# 現象

発言の中に `undefined` という文字列が含まれると、正しくない内容で送信される。

# 原因

発言名義指定記法（ `発言者名@` ）を併用していない場合、

```
  newComm = newComm.replace(reg2, function(whole, atMark, mStatus){
```

の時点で `reg2` の値が _undefined_ となっており、それが `String.prototype.replace` の第一引数として文字列型に型変換されて解釈されるため、 `undefined` という文字列を置き換えるという意味合いの動作になってしまう。

# 対処

`reg2` が非 null 値でなければ当該ステートメントを実行しないように。
