### PR TITLE
Fix: ステータス名に正規表現のメタ文字が含まれる場合に、簡易ステータス増減が正常に動作しない不具合を修正

### DIFF
--- a/lib/js/chat.js
+++ b/lib/js/chat.js
@@ -1681,6 +1681,9 @@ function nameCheck(name, comm){
     nameToColor[nameList[i]['name']] = nameList[i]['color'];
   }
   // コメントチェック
+  function escapeRegExp(text) {
+    return String(text).replace(/[.*+?^${}()|\[\]\\]/g, '\\$&');
+  }
   let reg1 = new RegExp("^("+names.join('|')+")?([@＠])");
   let reg2;
   // 名前
@@ -1696,7 +1699,7 @@ function nameCheck(name, comm){
     unitStatusNameUpdate(name);
     const status = (unitList[name] && unitList[name]['sttnames']) ? unitList[name]['sttnames'] : setStatus;
     console.log(status, after);
-    reg2 = new RegExp("^("+after+")((?:"+status.join('|')+")|メモ|memo|check|delete|new|add)?");
+    reg2 = new RegExp("^("+after+")((?:"+status.map(escapeRegExp).join('|')+")|メモ|memo|check|delete|new|add)?");
     return after;
   });
   // ステータス


### PR DESCRIPTION
# 現象

ステータス名に正規表現のメタ文字が含まれる場合に、簡易ステータス増減が正常に動作しない

## 例

下のようなユニットがあるとき、 `魔晶石(3点)` を簡易ステータス増減機能で操作しようとしても、うまくいかない。
<img width="208" height="65" alt="image" src="https://github.com/user-attachments/assets/a4a495f9-9d17-4253-b81e-d389cbc3fe49" />

具体的には、下のような通常のメッセージとして送信されてしまう。
<img width="250" height="34" alt="image" src="https://github.com/user-attachments/assets/690f626c-2a74-4fb1-967a-def064c9bf9f" />

# 原因

ステータス名から _RegExp_ オブジェクトをつくりだす実装があるが、メタ文字が考慮されていなかった。

# 対処

当該の実装箇所において、メタ文字をエスケープする。